### PR TITLE
Thumpback Tweaks

### DIFF
--- a/Resources/Maps/_Null/Shuttles/thumpback.yml
+++ b/Resources/Maps/_Null/Shuttles/thumpback.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/02/2025 01:15:58
+  time: 06/06/2025 00:11:36
   entityCount: 394
 maps: []
 grids:
@@ -1026,12 +1026,17 @@ entities:
   - uid: 216
     components:
     - type: Transform
-      pos: 3.5,4.5
+      pos: 3.5,3.5
       parent: 1
   - uid: 217
     components:
     - type: Transform
       pos: 4.5,4.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      pos: 4.5,3.5
       parent: 1
   - uid: 342
     components:
@@ -1187,6 +1192,8 @@ entities:
     - type: Transform
       pos: 0.5,29.5
       parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -1363,15 +1370,6 @@ entities:
       parent: 1
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 230
-    components:
-    - type: Transform
-      anchored: False
-      pos: 0.5,6.5
-      parent: 1
-    - type: Physics
-      canCollide: True
-      bodyType: Dynamic
   - uid: 231
     components:
     - type: Transform

--- a/Resources/Prototypes/_Null/Shipyard/thumpback.yml
+++ b/Resources/Prototypes/_Null/Shipyard/thumpback.yml
@@ -11,7 +11,7 @@
 - type: vessel
   id: Thumpback
   parent: BaseVessel
-  name: Thumpback
+  name: UNJ Thumpback
   description: A cheap but effective salvage shuttle.
   price: 30000
   category: Medium


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Added wiring (in red) to reach an unpowered thruster on the starboard couple.
- Removed wiring (black X) for visuals.
- Removed an unused atmos pipe that was hiding in the engineering airlock.
- Changed the shipyard console to include the ship's prefix when shopping. This now matches the vocal message played by the - console after a purchase.

## Why / Balance
Makes the ship better (not a legally binding guarantee).

## Media
![changes](https://github.com/user-attachments/assets/4719026a-13de-4c54-afa3-da758940cd15)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: LV cables rerouted to reach an unpowered thruster on the starboard couple.
- tweak: A stray atmos pipe hiding in the engineering airlock was returned to the void.
- tweak: Shipyard console now includes the ship's UNJ prefix.
