### PR TITLE
Camper Fix & Tweaks

### DIFF
--- a/Resources/Maps/_Null/Shuttles/camper.yml
+++ b/Resources/Maps/_Null/Shuttles/camper.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 05/22/2025 02:37:01
-  entityCount: 174
+  time: 06/06/2025 05:50:14
+  entityCount: 175
 maps: []
 grids:
 - 2
@@ -156,8 +156,6 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 138
-      - 148
       - 149
       - 136
       - 150
@@ -172,6 +170,20 @@ entities:
       parent: 2
     - type: Physics
       bodyType: Static
+- proto: Airlock
+  entities:
+  - uid: 39
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-4.5
+      parent: 2
+  - uid: 175
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 2
 - proto: AirlockExternalGlass
   entities:
   - uid: 56
@@ -193,20 +205,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-6.5
-      parent: 2
-- proto: AirlockServiceLocked
-  entities:
-  - uid: 38
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,-4.5
-      parent: 2
-  - uid: 39
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,-5.5
       parent: 2
 - proto: APCBasic
   entities:
@@ -401,20 +399,27 @@ entities:
       parent: 2
 - proto: Catwalk
   entities:
+  - uid: 38
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 2
   - uid: 69
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 2
-  - uid: 70
-    components:
-    - type: Transform
-      pos: -0.5,-7.5
-      parent: 2
   - uid: 71
     components:
     - type: Transform
       pos: -0.5,-8.5
+      parent: 2
+  - uid: 138
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,-7.5
       parent: 2
 - proto: ChairPilotSeat
   entities:
@@ -530,6 +535,14 @@ entities:
       color: '#990000FF'
 - proto: GasPipeBend
   entities:
+  - uid: 103
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 147
     components:
     - type: Transform
@@ -613,14 +626,6 @@ entities:
     components:
     - type: Transform
       pos: -2.5,-0.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 155
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,-8.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -710,6 +715,14 @@ entities:
       color: '#0055CCFF'
 - proto: GasVentPump
   entities:
+  - uid: 70
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 136
     components:
     - type: Transform
@@ -736,32 +749,14 @@ entities:
       - 115
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 138
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-7.5
-      parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 115
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
-  - uid: 148
+  - uid: 75
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -0.5,-8.5
+      pos: -1.5,-8.5
       parent: 2
-    - type: DeviceNetwork
-      configurators:
-      - invalid
-      deviceLists:
-      - 115
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 149
@@ -792,7 +787,7 @@ entities:
       color: '#990000FF'
 - proto: GravityGeneratorMini
   entities:
-  - uid: 75
+  - uid: 155
     components:
     - type: Transform
       pos: -1.5,-7.5
@@ -940,10 +935,10 @@ entities:
       parent: 2
 - proto: ShelfWallFreezerWhite
   entities:
-  - uid: 103
+  - uid: 148
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
+      rot: 1.5707963267948966 rad
       pos: -2.5,-4.5
       parent: 2
 - proto: ShuttersNormalOpen
@@ -1000,7 +995,7 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        38:
+        39:
         - Pressed: DoorBolt
   - uid: 100
     components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Changed the two service airlocks to regular airlocks (and reconnected the bathroom bolt button).
- Added a catwalk underneath the airlock next to the air alarm.
- Rotated the Wall Freezer to face the inside of the ship.
- Hid the air scrubber and vent in the rear of the ship. The previous position of the vent was visually clipping with the catwalks.

## Why / Balance
Better ship works better.
Prettier ship is prettier.

## Media
![2025-6-05_23 03 05](https://github.com/user-attachments/assets/8d74f2a3-542c-42ce-ba91-8dd973f41472)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- tweak: Changed two service airlocks to regular airlocks.
- fix: Rotated the Wall Freezer to face the interior of the shuttle.
- tweak: Hid the Air Vent and Scrubber in the rear of the ship.
- add: Catwalk underneath the regular airlock to the ship's rear.