### PR TITLE
20250606 : Fixes, Rings, Summary Webhook, Blips

### DIFF
--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -14,6 +14,7 @@ using Robust.Shared.Map;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Components;
+
 // Frontier
 
 // Frontier
@@ -498,6 +499,6 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
     }
 
     private const int RadarBlipSize = 15;
-    private const int RadarFontSize = 10;
+    private const int RadarFontSize = 8;
 
 }

--- a/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -204,7 +204,7 @@ public sealed partial class ShuttleNavControl : BaseShuttleControl
 
         // Draw radar position on the station
         const float radarVertRadius = 2f;
-        var radarPosVerts = new Vector2[]
+        var radarPosVerts = new[]
         {
             ScalePosition(new Vector2(0f, -radarVertRadius)),
             ScalePosition(new Vector2(radarVertRadius / 2f, 0f)),

--- a/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
+++ b/Content.Client/_Mono/FireControl/UI/FireControlNavControl.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Numerics;
 using Content.Client._NF.Radar;
+using Content.Client._Null;
 using Content.Client.Shuttles.UI;
 using Content.Shared._Mono.FireControl;
 using Content.Shared._NF.Radar;
@@ -314,7 +315,7 @@ public sealed class FireControlNavControl : BaseShuttleControl
         {
             var blipPos = Vector2.Transform(blip.Item1, worldToShuttle * shuttleToView);
 
-            if (blip.Item4 == RadarBlipShape.Circle)
+            if (blip.Item4 == RadarBlipShape.Ring)
             {
                 // For Ring shapes, use the real radius but with a dedicated drawing method
                 DrawShieldRing(handle, blipPos, blip.Item2 * MinimapScale, blip.Item3.WithAlpha(0.8f));
@@ -375,6 +376,9 @@ public sealed class FireControlNavControl : BaseShuttleControl
     {
         switch (shape)
         {
+            case RadarBlipShape.Ring:
+                handle.DrawRing(position, size, color);
+                break;
             case RadarBlipShape.Circle:
                 handle.DrawCircle(position, size, color);
                 break;
@@ -389,7 +393,7 @@ public sealed class FireControlNavControl : BaseShuttleControl
                 handle.DrawRect(rect, color);
                 break;
             case RadarBlipShape.Triangle:
-                var points = new Vector2[]
+                var points = new[]
                 {
                     position + new Vector2(0, -size),
                     position + new Vector2(-size * 0.866f, size * 0.5f),

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -243,7 +243,7 @@ public sealed partial class ShuttleNavControl
                 handle.DrawRect(rect, color);
                 break;
             case RadarBlipShape.Triangle:
-                var points = new Vector2[]
+                var points = new[]
                 {
                 position + new Vector2(0, -size),
                 position + new Vector2(-size * 0.866f, size * 0.5f),

--- a/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
+++ b/Content.Client/_NF/Shuttles/UI/ShuttleNavControl.xaml.cs
@@ -1,5 +1,6 @@
 using System.Numerics;
 using Content.Client._NF.Radar;
+using Content.Client._Null;
 using Content.Client.Station;
 using Content.Shared._NF.Radar;
 using Content.Shared._NF.Shuttles.Events;
@@ -225,6 +226,9 @@ public sealed partial class ShuttleNavControl
     {
         switch (shape)
         {
+            case RadarBlipShape.Ring:
+                handle.DrawRing(position, size, color);
+                break;
             case RadarBlipShape.Circle:
                 handle.DrawCircle(position, size, color);
                 break;

--- a/Content.Client/_Null/DrawingHandleExtensions.cs
+++ b/Content.Client/_Null/DrawingHandleExtensions.cs
@@ -1,0 +1,24 @@
+using System.Numerics;
+using Robust.Client.Graphics;
+
+namespace Content.Client._Null;
+
+public static class DrawingHandleExtensions
+{
+
+    // Null Sector port of Monolith w. Reposition
+    /// <summary>
+    /// Draws a shield ring with constant thickness regardless of zoom level.
+    /// </summary>
+    public static void DrawRing(this DrawingHandleBase handle, Vector2 position, float radius, Color color)
+    {
+        // Draw the shield outline as a ring with constant thickness
+        const float ringThickness = 2.0f; // Fixed thickness in pixels
+
+        // Draw multiple circles with slightly different radii to create a solid ring effect
+        for (float offset = 0; offset <= ringThickness; offset += 0.5f)
+        {
+            handle.DrawCircle(position, radius + offset, color.WithAlpha(0.5f), false);
+        }
+    }
+}

--- a/Content.Server/GameTicking/GameTicker.RoundFlow.cs
+++ b/Content.Server/GameTicking/GameTicker.RoundFlow.cs
@@ -435,7 +435,7 @@ namespace Content.Server.GameTicking
                     return;
                 }
 
-                // MapInitialize *before* spawning players, our codebase is too shit to do it afterwards...
+                // MapInitialize must be done -before- spawning players, else it will not work.
                 _map.InitializeMap(DefaultMap);
 
                 SpawnPlayers(readyPlayers, readyPlayerProfiles, force);
@@ -709,7 +709,17 @@ namespace Content.Server.GameTicking
                 var showUsername = false; // 'false' by default, it is an opt-in feature.t
 
                 if (_playerManager.TryGetSessionById(player.PlayerGuid, out var ds))
-                    showUsername = _netConfigManager.GetClientCVar(ds.Channel, NullCCVars.DisplayUsernameInSummary);
+                {
+                    try
+                    {
+                        // This can fail to get client CVar. It is not optimal, but this prevents an all-out break.
+                        showUsername = _netConfigManager.GetClientCVar(ds.Channel, NullCCVars.DisplayUsernameInSummary);
+                    }
+                    catch(Exception e)
+                    {
+                        Logger.Error(e.ToString());
+                    }
+                }
 
                 // - PLAYER was CHARACTER playing role of ROLE. |OR| // - CHARACTER playing role of ROLE.
                 var playerLine = showUsername

--- a/Content.Server/Theta/ShipEvent/Systems/CircularShieldRadarSystem.cs
+++ b/Content.Server/Theta/ShipEvent/Systems/CircularShieldRadarSystem.cs
@@ -155,7 +155,7 @@ public sealed class CircularShieldRadarSystem : EntitySystem
         var radarComp = EnsureComp<RadarBlipComponent>(blipEntity);
         radarComp.RadarColor = shield.Color;
         radarComp.Scale = shield.Radius;
-        radarComp.Shape = RadarBlipShape.Circle;
+        radarComp.Shape = RadarBlipShape.Ring;
         radarComp.Enabled = shield.CanWork;
         radarComp.VisibleFromOtherGrids = true;
 

--- a/Content.Server/_NF/Radar/RadarBlipComponent.cs
+++ b/Content.Server/_NF/Radar/RadarBlipComponent.cs
@@ -30,7 +30,7 @@ public sealed partial class RadarBlipComponent : Component
     /// The shape of the blip on the radar.
     /// </summary>
     [DataField]
-    public RadarBlipShape Shape { get; set; } = RadarBlipShape.Circle;
+    public RadarBlipShape Shape { get; set; } = RadarBlipShape.Ring;
 
     /// <summary>
     /// Whether this blip should be shown even when parented to a grid.

--- a/Content.Shared/CCVar/CCVars.Chat.Ooc.cs
+++ b/Content.Shared/CCVar/CCVars.Chat.Ooc.cs
@@ -17,7 +17,7 @@ public sealed partial class CCVars
         CVarDef.Create("ooc.disabling_ooc_disables_relay", true, CVar.SERVERONLY);
 
     /// <summary>
-    ///     Whether or not OOC chat should be enabled during a round.
+    ///     Whether OOC chat should be enabled during a round.
     /// </summary>
     public static readonly CVarDef<bool> OocEnableDuringRound =
         CVarDef.Create("ooc.enable_during_round", false, CVar.NOTIFY | CVar.REPLICATED | CVar.SERVER);

--- a/Content.Shared/_NF/Radar/RadarMessages.cs
+++ b/Content.Shared/_NF/Radar/RadarMessages.cs
@@ -23,7 +23,9 @@ public enum RadarBlipShape
     /// <summary>Hexagon shape.</summary>
     Hexagon,
     /// <summary>Arrow shape.</summary>
-    Arrow
+    Arrow,
+    /// <summary>Ring shape.</summary>
+    Ring,
 }
 
 /// <summary>

--- a/Content.Shared/_Null/CCVar/NullCCVars.cs
+++ b/Content.Shared/_Null/CCVar/NullCCVars.cs
@@ -1,14 +1,16 @@
+using Robust.Shared;
 using Robust.Shared.Configuration;
 
 namespace Content.Shared._Null.CCVar;
 
+// NOTE: This class is lifted from RMC14, however most CVars were removed.
+
 [CVarDefs]
-public sealed class NullCCVars
+public sealed partial class NullCCVars : CVars
 {
     /// <summary>
     /// Null: Toggle Displaying Username in End of Round Summary Webhook(TM). False by default.
     /// </summary>
     public static readonly CVarDef<bool> DisplayUsernameInSummary =
-        CVarDef.Create("display.display_username_in_summary", false, CVar.CLIENTONLY | CVar.ARCHIVE);
-
+        CVarDef.Create("discord.display_username_in_summary", false, CVar.REPLICATED | CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Content.Shared/_Null/Systems/UserToggleRoundUsername.cs
+++ b/Content.Shared/_Null/Systems/UserToggleRoundUsername.cs
@@ -1,0 +1,20 @@
+using Content.Shared._Null.CCVar;
+using Robust.Shared.Configuration;
+
+namespace Content.Shared._Null.Systems;
+
+public sealed class UserToggleRoundUsername : EntitySystem
+{
+    [Dependency] private   readonly IConfigurationManager _cfg = default!;
+    public bool DisplayUsernameInSummary = true;
+
+    public new void Initialize()
+    {
+        base.Initialize();
+        Subs.CVar(_cfg, NullCCVars.DisplayUsernameInSummary, OnPreferenceChanged, true);
+    }
+    private void OnPreferenceChanged(bool obj)
+    {
+        DisplayUsernameInSummary = obj;
+    }
+}

--- a/Resources/Maps/_Mono/Outpost/frontier.yml
+++ b/Resources/Maps/_Mono/Outpost/frontier.yml
@@ -63,7 +63,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -4333,7 +4333,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 52
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -4346,7 +4346,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 52
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -4359,7 +4359,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 52
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -4372,7 +4372,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 52
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/ShuttleEvent/razor.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/razor.yml
@@ -143,7 +143,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -156,7 +156,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/ShuttleEvent/zenith.yml
+++ b/Resources/Maps/_Mono/ShuttleEvent/zenith.yml
@@ -213,7 +213,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -226,7 +226,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -239,7 +239,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -252,7 +252,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -265,7 +265,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -278,7 +278,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -291,7 +291,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/exocron.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/exocron.yml
@@ -266,7 +266,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -279,7 +279,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -292,7 +292,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -305,7 +305,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -318,7 +318,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -331,7 +331,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -344,7 +344,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -357,7 +357,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -370,7 +370,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -383,7 +383,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -396,7 +396,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -409,7 +409,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -422,7 +422,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -435,7 +435,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -448,7 +448,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/kessler.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/kessler.yml
@@ -407,7 +407,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -420,7 +420,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -433,7 +433,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -446,7 +446,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -459,7 +459,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/BlackMarket/mercury.yml
+++ b/Resources/Maps/_Mono/Shuttles/BlackMarket/mercury.yml
@@ -756,7 +756,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -769,7 +769,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -782,7 +782,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Expedition/archon.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/archon.yml
@@ -476,7 +476,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -489,7 +489,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -502,7 +502,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Expedition/judiciary.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/judiciary.yml
@@ -431,7 +431,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -444,7 +444,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -457,7 +457,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -470,7 +470,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -483,7 +483,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -496,7 +496,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -509,7 +509,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Expedition/littora.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/littora.yml
@@ -926,7 +926,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Expedition/picses.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/picses.yml
@@ -565,7 +565,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -578,7 +578,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Expedition/praetorian_expd.yml
+++ b/Resources/Maps/_Mono/Shuttles/Expedition/praetorian_expd.yml
@@ -400,7 +400,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -413,7 +413,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -426,7 +426,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/anura.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/anura.yml
@@ -551,7 +551,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -564,7 +564,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/calypso.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/calypso.yml
@@ -560,7 +560,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -573,7 +573,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -586,7 +586,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/dart.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/dart.yml
@@ -234,7 +234,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -247,7 +247,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -260,7 +260,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/Nfsd/mayhem.yml
+++ b/Resources/Maps/_Mono/Shuttles/Nfsd/mayhem.yml
@@ -687,7 +687,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -700,7 +700,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
 - proto: AirAlarm

--- a/Resources/Maps/_Mono/Shuttles/Service/arachnid.yml
+++ b/Resources/Maps/_Mono/Shuttles/Service/arachnid.yml
@@ -317,7 +317,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -330,7 +330,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -343,7 +343,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/praetorian.yml
+++ b/Resources/Maps/_Mono/Shuttles/praetorian.yml
@@ -400,7 +400,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -413,7 +413,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Shuttles/tzipora.yml
+++ b/Resources/Maps/_Mono/Shuttles/tzipora.yml
@@ -956,7 +956,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -969,7 +969,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -982,7 +982,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -995,7 +995,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Mono/Test/dev_map.yml
+++ b/Resources/Maps/_Mono/Test/dev_map.yml
@@ -400,7 +400,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
 - proto: AdvancedCapacitorStockPart

--- a/Resources/Maps/_Null/Outpost/lark.yml
+++ b/Resources/Maps/_Null/Outpost/lark.yml
@@ -50,7 +50,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2335,7 +2335,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2348,7 +2348,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2361,7 +2361,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2386,7 +2386,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2399,7 +2399,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2412,7 +2412,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2425,7 +2425,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2438,7 +2438,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -2451,7 +2451,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Null/Shuttles/Expedition/crapbucket.yml
+++ b/Resources/Maps/_Null/Shuttles/Expedition/crapbucket.yml
@@ -32,7 +32,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -196,7 +196,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
@@ -209,7 +209,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       scale: 0
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar

--- a/Resources/Maps/_Null/Test/dev_map.yml
+++ b/Resources/Maps/_Null/Test/dev_map.yml
@@ -421,7 +421,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
   - uid: 797
@@ -433,7 +433,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
   - uid: 798
@@ -445,7 +445,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
   - uid: 799
@@ -457,7 +457,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
   - uid: 1646
@@ -469,7 +469,7 @@ entities:
     - type: RadarBlip
       enabled: False
       visibleFromOtherGrids: True
-      shape: Circle
+      shape: Ring
       radarColor: '#00DEFEFF'
     - type: CircularShieldRadar
 - proto: AdvancedCapacitorStockPart

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -125,6 +125,10 @@
     - id: WristwatchGold
     - !type:NestedSelector
       tableId: RingTableCommon
+    - id: CassetteTapesSpawner
+      weight: 0.05
+    - id: CassettePlayer
+      weight: 0.02
 
 - type: entityTable
   id: SalvageTreasureRare
@@ -156,10 +160,6 @@
           weight: 14
         - id: SpaceCash10000
           weight: 1
-    - id: CassetteTapesSpawner
-      weight: 0.5
-    - id: CassettePlayer
-      weight: 0.2
     - !type:NestedSelector
       tableId: RingTableRare
     - id: CardBoxNanotrasen # Frontier


### PR DESCRIPTION
# 20250606
- Added Rings back to Blip System
*Warning: **shield** Rings do indeed render, however they currently scale with zoom level. This is not correct behaviour. -Z*
- Set Old Ship Shield Gen. Blips to Rings
- Fixed shields being Circles. They're Rings, now!
- Pseudo-Fixed End of Round Webhook Username Preference
*Warning: Basically the user has a choice whether or not they want their username to appear in the end of round summary sent via webhook to discord. However, this option does not actually work. I do not know exactly why, but the CCVar is not properly "registered" in the system. I don't know how to fix this, so for now it defaults to "false" regardless of user preference. Someone more familiar with registering CCVars will need to look at this. -Z*