### PR TITLE
Miriam Fix & Guideline Changes

### DIFF
--- a/Resources/Maps/_Null/Shuttles/miriam.yml
+++ b/Resources/Maps/_Null/Shuttles/miriam.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 04/23/2025 20:33:49
-  entityCount: 661
+  time: 06/07/2025 14:24:42
+  entityCount: 678
 maps: []
 grids:
 - 1
@@ -335,13 +335,15 @@ entities:
             1: 296
             0: 60416
           0,1:
-            0: 64988
+            2: 16
+            0: 64972
           -1,1:
             0: 65520
           0,2:
             0: 56797
           -1,2:
-            0: 52975
+            0: 36591
+            3: 16384
             1: 4096
           0,3:
             1: 59408
@@ -360,7 +362,8 @@ entities:
           1,3:
             0: 60959
           1,4:
-            0: 206
+            3: 2
+            0: 204
             1: 528
           2,0:
             1: 4096
@@ -392,7 +395,7 @@ entities:
             1: 65529
           3,4:
             1: 27474
-            2: 4096
+            4: 4096
           2,5:
             1: 8
           3,5:
@@ -420,6 +423,36 @@ entities:
           moles:
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.1499
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.14996
+          moles:
+          - 21.824879
+          - 82.10312
           - 0
           - 0
           - 0
@@ -555,7 +588,7 @@ entities:
       pos: 3.5,13.5
       parent: 1
     - type: DeviceLinkSink
-      invokeCounter: 2
+      invokeCounter: 3
     - type: DeviceLinkSource
       linkedPorts:
         79:
@@ -568,7 +601,7 @@ entities:
       pos: 8.5,9.5
       parent: 1
     - type: DeviceLinkSink
-      invokeCounter: 2
+      invokeCounter: 3
     - type: DeviceLinkSource
       linkedPorts:
         79:
@@ -602,6 +635,9 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,10.5
       parent: 1
+    - type: Door
+      secondsUntilStateChange: -8144.5625
+      state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
     - type: DeviceLinkSource
@@ -610,6 +646,8 @@ entities:
         - DoorStatus: DoorBolt
         159:
         - DoorStatus: DoorBolt
+      lastSignals:
+        DoorStatus: True
 - proto: AirlockHydroponics
   entities:
   - uid: 161
@@ -725,6 +763,29 @@ entities:
     components:
     - type: Transform
       pos: 2.5,0.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      pos: 6.5,12.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
       parent: 1
 - proto: AtmosFixBlockerMarker
   entities:
@@ -1271,6 +1332,13 @@ entities:
     components:
     - type: Transform
       pos: -2.5,3.5
+      parent: 1
+- proto: BedsheetMedical
+  entities:
+  - uid: 667
+    components:
+    - type: Transform
+      pos: 5.5,16.5
       parent: 1
 - proto: BedsheetNT
   entities:
@@ -2439,6 +2507,14 @@ entities:
     - type: Transform
       pos: 14.5,19.5
       parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 678
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 10.5,14.5
+      parent: 1
 - proto: ChemDispenser
   entities:
   - uid: 244
@@ -2448,7 +2524,7 @@ entities:
       parent: 1
 - proto: ChemistryHotplate
   entities:
-  - uid: 245
+  - uid: 148
     components:
     - type: Transform
       pos: -1.5,11.5
@@ -2475,6 +2551,25 @@ entities:
     - type: Transform
       pos: 5.5,15.5
       parent: 1
+    - type: GroupExamine
+      group:
+      - hoverMessage: ""
+        contextText: verb-examine-group-other
+        icon: /Textures/Interface/examine-star.png
+        components:
+        - Armor
+        - ClothingSpeedModifier
+        entries:
+        - message: >-
+            It provides the following protection:
+
+            - [color=orange]Explosion[/color] damage [color=white]to contents[/color] reduced by [color=lightblue]10%[/color].
+          priority: 0
+          component: Armor
+        - message: This decreases your running speed by [color=yellow]10%[/color].
+          priority: 0
+          component: ClothingSpeedModifier
+        title: null
 - proto: ComputerGunneryConsole
   entities:
   - uid: 527
@@ -2507,6 +2602,8 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 11.5,14.5
       parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
     - type: ApcPowerReceiver
       powerLoad: 5
     - type: Battery
@@ -2575,6 +2672,21 @@ entities:
     components:
     - type: Transform
       pos: 5.5,17.5
+      parent: 1
+- proto: EmergencyRollerBed
+  entities:
+  - uid: 675
+    components:
+    - type: Transform
+      pos: 7.477951,16.772041
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 666
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
       parent: 1
 - proto: FaxMachineShip
   entities:
@@ -3442,6 +3554,20 @@ entities:
     - type: Transform
       pos: 12.5,19.5
       parent: 1
+- proto: Grille
+  entities:
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,15.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,14.5
+      parent: 1
 - proto: GunneryServer
   entities:
   - uid: 657
@@ -3449,6 +3575,10 @@ entities:
     - type: Transform
       pos: 10.5,17.5
       parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
 - proto: Gyroscope
   entities:
   - uid: 507
@@ -3457,7 +3587,7 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 9.5,7.5
       parent: 1
-- proto: hydroponicsTrayAnchored
+- proto: hydroponicsTray
   entities:
   - uid: 173
     components:
@@ -3496,6 +3626,13 @@ entities:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 677
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
 - proto: LockerCaptainFilledHardsuit
   entities:
   - uid: 659
@@ -3505,7 +3642,7 @@ entities:
       parent: 1
 - proto: LockerChemistryFilled
   entities:
-  - uid: 191
+  - uid: 147
     components:
     - type: Transform
       pos: 0.5,5.5
@@ -3516,6 +3653,13 @@ entities:
     components:
     - type: Transform
       pos: -0.5,2.5
+      parent: 1
+- proto: LockerParamedicFilledHardsuit
+  entities:
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 7.5,14.5
       parent: 1
 - proto: LockerWallColorHydroponicsFilled
   entities:
@@ -3546,12 +3690,33 @@ entities:
     - type: Transform
       pos: -3.5,8.5
       parent: 1
+- proto: MachineFTLDrive
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+- proto: MedicalBed
+  entities:
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 5.5,16.5
+      parent: 1
 - proto: MedicalTechFab
   entities:
   - uid: 204
     components:
     - type: Transform
       pos: -3.5,7.5
+      parent: 1
+- proto: MedkitFilled
+  entities:
+  - uid: 674
+    components:
+    - type: Transform
+      pos: 5.493576,16.553291
       parent: 1
 - proto: NFHolopadShip
   entities:
@@ -3580,9 +3745,9 @@ entities:
       parent: 1
     - type: Physics
       bodyType: Static
-- proto: PortableGeneratorSuperPacman
+- proto: PortableGeneratorSuperPacmanShuttle
   entities:
-  - uid: 517
+  - uid: 176
     components:
     - type: Transform
       pos: 13.5,20.5
@@ -3596,10 +3761,10 @@ entities:
       parent: 1
 - proto: PottedPlant22
   entities:
-  - uid: 176
+  - uid: 676
     components:
     - type: Transform
-      pos: 5.5,8.5
+      pos: 4.5,8.5
       parent: 1
 - proto: PowerCellRecharger
   entities:
@@ -3687,6 +3852,20 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
+- proto: ReinforcedWindow
+  entities:
+  - uid: 245
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,14.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 12.5,15.5
+      parent: 1
 - proto: SeedExtractor
   entities:
   - uid: 236
@@ -3739,6 +3918,14 @@ entities:
     - type: Transform
       pos: 12.5,17.5
       parent: 1
+- proto: SpawnPointLatejoin
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
 - proto: StasisBed
   entities:
   - uid: 216
@@ -3790,6 +3977,7 @@ entities:
   - uid: 242
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 1
   - uid: 243
@@ -4131,16 +4319,6 @@ entities:
     - type: Transform
       pos: 12.5,16.5
       parent: 1
-  - uid: 147
-    components:
-    - type: Transform
-      pos: 12.5,15.5
-      parent: 1
-  - uid: 148
-    components:
-    - type: Transform
-      pos: 12.5,14.5
-      parent: 1
   - uid: 149
     components:
     - type: Transform
@@ -4481,6 +4659,14 @@ entities:
     components:
     - type: Transform
       pos: 4.5,17.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
       parent: 1
 - proto: WaterCooler
   entities:

--- a/Resources/Maps/_Null/Shuttles/miriam.yml
+++ b/Resources/Maps/_Null/Shuttles/miriam.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/07/2025 14:24:42
+  time: 06/07/2025 15:02:23
   entityCount: 678
 maps: []
 grids:
@@ -636,7 +636,7 @@ entities:
       pos: 5.5,10.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -8144.5625
+      secondsUntilStateChange: -8297.753
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
@@ -4244,11 +4244,6 @@ entities:
     - type: Transform
       pos: 7.5,8.5
       parent: 1
-  - uid: 132
-    components:
-    - type: Transform
-      pos: 4.5,3.5
-      parent: 1
   - uid: 133
     components:
     - type: Transform
@@ -4263,11 +4258,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,15.5
-      parent: 1
-  - uid: 136
-    components:
-    - type: Transform
-      pos: 4.5,4.5
       parent: 1
   - uid: 137
     components:
@@ -4354,11 +4344,6 @@ entities:
     - type: Transform
       pos: 7.5,11.5
       parent: 1
-  - uid: 157
-    components:
-    - type: Transform
-      pos: 4.5,5.5
-      parent: 1
   - uid: 170
     components:
     - type: Transform
@@ -4369,70 +4354,15 @@ entities:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 172
-    components:
-    - type: Transform
-      pos: 1.5,5.5
-      parent: 1
   - uid: 185
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
-  - uid: 187
-    components:
-    - type: Transform
-      pos: 1.5,10.5
-      parent: 1
-  - uid: 188
-    components:
-    - type: Transform
-      pos: 1.5,4.5
-      parent: 1
-  - uid: 192
-    components:
-    - type: Transform
-      pos: 1.5,11.5
-      parent: 1
-  - uid: 193
-    components:
-    - type: Transform
-      pos: -2.5,4.5
-      parent: 1
-  - uid: 196
-    components:
-    - type: Transform
-      pos: -0.5,4.5
-      parent: 1
   - uid: 197
     components:
     - type: Transform
       pos: 1.5,8.5
-      parent: 1
-  - uid: 198
-    components:
-    - type: Transform
-      pos: 6.5,7.5
-      parent: 1
-  - uid: 200
-    components:
-    - type: Transform
-      pos: 4.5,7.5
-      parent: 1
-  - uid: 202
-    components:
-    - type: Transform
-      pos: 0.5,4.5
-      parent: 1
-  - uid: 203
-    components:
-    - type: Transform
-      pos: 1.5,6.5
-      parent: 1
-  - uid: 206
-    components:
-    - type: Transform
-      pos: 5.5,7.5
       parent: 1
   - uid: 209
     components:
@@ -4443,26 +4373,6 @@ entities:
     components:
     - type: Transform
       pos: 4.5,16.5
-      parent: 1
-  - uid: 226
-    components:
-    - type: Transform
-      pos: -1.5,4.5
-      parent: 1
-  - uid: 228
-    components:
-    - type: Transform
-      pos: 0.5,2.5
-      parent: 1
-  - uid: 231
-    components:
-    - type: Transform
-      pos: 4.5,2.5
-      parent: 1
-  - uid: 233
-    components:
-    - type: Transform
-      pos: 1.5,9.5
       parent: 1
   - uid: 357
     components:
@@ -4483,21 +4393,6 @@ entities:
     components:
     - type: Transform
       pos: 15.5,19.5
-      parent: 1
-  - uid: 530
-    components:
-    - type: Transform
-      pos: 9.5,14.5
-      parent: 1
-  - uid: 531
-    components:
-    - type: Transform
-      pos: 9.5,15.5
-      parent: 1
-  - uid: 532
-    components:
-    - type: Transform
-      pos: 9.5,17.5
       parent: 1
 - proto: WallReinforcedDiagonal
   entities:
@@ -4659,6 +4554,113 @@ entities:
     components:
     - type: Transform
       pos: 4.5,17.5
+      parent: 1
+- proto: WallSolid
+  entities:
+  - uid: 132
+    components:
+    - type: Transform
+      pos: 4.5,3.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 157
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 172
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 187
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+  - uid: 193
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 196
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: 4.5,7.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 0.5,4.5
+      parent: 1
+  - uid: 203
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: 9.5,14.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: 9.5,15.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 9.5,17.5
       parent: 1
 - proto: WarpPoint
   entities:

--- a/Resources/Prototypes/_Null/Shipyard/miriam.yml
+++ b/Resources/Prototypes/_Null/Shipyard/miriam.yml
@@ -6,11 +6,11 @@
   id: Miriam
   parent: BaseVessel
   name: SKR Miriam
-  description: A modestly sized medical vessel equipped with all the equipment required to operate a cryogenics laboratory.
+  description: A fully supported cryogenics laboratory with a unique dual-hull design.
   price: 41070
   category: Medium
   group: Medical
-  shuttlePath: /Maps/_Mono/Shuttles/miriam.yml
+  shuttlePath: /Maps/_Null/Shuttles/miriam.yml
   guidebookPage: null
   class:
   - Medical
@@ -20,7 +20,7 @@
 - type: gameMap
   id: Miriam
   mapName: 'SKR Miriam'
-  mapPath: /Maps/_Mono/Shuttles/miriam.yml
+  mapPath: /Maps/_Null/Shuttles/miriam.yml
   minPlayers: 0
   stations:
     Miriam:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
- Fixed generator to use ship variant instead of normal.
- Tweaked description to reduce repetition with itself and the Eden.
- Changed some reinforced walls on the interior of the ship to solid walls.
- Added fans between interior/exterior airlocks.
- Added latejoin spawn point.
- Added warp point and CTLA-25 bluespace drive.
- Added reinforced windows to cockpit.
- Added pilot seat to cockpit.
- Added paramedic locker.
- Added roller bed.
- Added medical bed.
- Added first aid kit.
- Added reagent grinder.
- Added fire extinguisher cabinet.
- Migrated the ship into the Null directory.

## Media
![miriamneochanges](https://github.com/user-attachments/assets/726fe72d-3e7a-47c5-ad69-67efcc055e56)

