### PR TITLE
Fixes errors from invalid yaml entries

### DIFF
--- a/Resources/Maps/_Mono/Shuttles/bison.yml
+++ b/Resources/Maps/_Mono/Shuttles/bison.yml
@@ -2252,8 +2252,6 @@ entities:
       pos: 0.5,-7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
   - uid: 560
@@ -2263,8 +2261,6 @@ entities:
       pos: 1.5,-7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
   - uid: 561
@@ -2274,8 +2270,6 @@ entities:
       pos: 2.5,-7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
 - proto: GasMixerOnFlipped
@@ -2838,8 +2832,6 @@ entities:
       pos: -1.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2850,8 +2842,6 @@ entities:
       pos: 4.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2871,8 +2861,6 @@ entities:
       pos: -1.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2884,8 +2872,6 @@ entities:
       pos: 4.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2897,8 +2883,6 @@ entities:
       pos: 4.5,-7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2910,8 +2894,6 @@ entities:
       pos: 1.5,-3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2923,8 +2905,6 @@ entities:
       pos: 1.5,-10.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2935,8 +2915,6 @@ entities:
       pos: 0.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2950,8 +2928,6 @@ entities:
       pos: -0.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2963,8 +2939,6 @@ entities:
       pos: 1.5,-9.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2976,8 +2950,6 @@ entities:
       pos: 1.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -2989,8 +2961,6 @@ entities:
       pos: -1.5,-8.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -3002,8 +2972,6 @@ entities:
       pos: 4.5,-8.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -3015,8 +2983,6 @@ entities:
       pos: 4.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -3028,8 +2994,6 @@ entities:
       pos: -1.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor
@@ -3041,8 +3005,6 @@ entities:
       pos: 3.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 558
     - type: AtmosPipeColor

--- a/Resources/Maps/_Mono/Shuttles/coldcap.yml
+++ b/Resources/Maps/_Mono/Shuttles/coldcap.yml
@@ -887,8 +887,6 @@ entities:
       pos: -4.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 312
       - 341
@@ -899,8 +897,6 @@ entities:
       pos: -0.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 312
       - 341
@@ -911,8 +907,6 @@ entities:
       pos: 1.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 312
       - 341
@@ -923,8 +917,6 @@ entities:
       pos: 5.5,2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 312
       - 341

--- a/Resources/Maps/_Mono/Shuttles/donkhaus.yml
+++ b/Resources/Maps/_Mono/Shuttles/donkhaus.yml
@@ -986,8 +986,6 @@ entities:
       pos: 12.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 690
@@ -997,8 +995,6 @@ entities:
       pos: 15.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 691
@@ -1008,8 +1004,6 @@ entities:
       pos: 7.5,6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 692
@@ -1019,8 +1013,6 @@ entities:
       pos: 8.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 693
@@ -1030,8 +1022,6 @@ entities:
       pos: -4.5,1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
 - proto: AlwaysPoweredLightExterior
@@ -2332,8 +2322,6 @@ entities:
       pos: 13.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 681
@@ -2343,8 +2331,6 @@ entities:
       pos: 5.5,6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 682
@@ -2354,8 +2340,6 @@ entities:
       pos: 8.5,5.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 683
@@ -2365,8 +2349,6 @@ entities:
       pos: 8.5,1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 684
@@ -2376,8 +2358,6 @@ entities:
       pos: 10.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
 - proto: FirelockEdge
@@ -2389,8 +2369,6 @@ entities:
       pos: 1.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 686
@@ -2400,8 +2378,6 @@ entities:
       pos: 1.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 687
@@ -2411,8 +2387,6 @@ entities:
       pos: 1.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
   - uid: 688
@@ -2422,8 +2396,6 @@ entities:
       pos: 1.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
 - proto: FloorDrain
@@ -2982,8 +2954,6 @@ entities:
       pos: 14.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -2994,8 +2964,6 @@ entities:
       pos: 11.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3006,8 +2974,6 @@ entities:
       pos: 8.5,4.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3018,8 +2984,6 @@ entities:
       pos: 0.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3031,8 +2995,6 @@ entities:
       pos: -14.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3044,8 +3006,6 @@ entities:
       pos: 8.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3059,8 +3019,6 @@ entities:
       pos: -6.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3072,8 +3030,6 @@ entities:
       pos: -2.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor
@@ -3085,8 +3041,6 @@ entities:
       pos: -10.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 678
     - type: AtmosPipeColor

--- a/Resources/Maps/_Mono/Shuttles/gudinov.yml
+++ b/Resources/Maps/_Mono/Shuttles/gudinov.yml
@@ -702,8 +702,6 @@ entities:
       pos: -0.5,-6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 151
 - proto: GasVentScrubber
@@ -715,8 +713,6 @@ entities:
       pos: 0.5,-6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 151
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Mono/Shuttles/penman.yml
+++ b/Resources/Maps/_Mono/Shuttles/penman.yml
@@ -312,8 +312,6 @@ entities:
       pos: 0.5,-2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
 - proto: AlwaysPoweredLightExterior
@@ -819,8 +817,6 @@ entities:
       pos: 0.5,3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
 - proto: GasMixerOnFlipped
@@ -1046,8 +1042,6 @@ entities:
       pos: 0.5,-1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
     - type: AtmosPipeColor
@@ -1059,8 +1053,6 @@ entities:
       pos: 0.5,6.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
     - type: AtmosPipeColor
@@ -1074,8 +1066,6 @@ entities:
       pos: 0.5,5.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
     - type: AtmosPipeColor
@@ -1087,8 +1077,6 @@ entities:
       pos: 0.5,-3.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 82
     - type: AtmosPipeColor

--- a/Resources/Maps/_Null/Shuttles/Civilian/camper.yml
+++ b/Resources/Maps/_Null/Shuttles/Civilian/camper.yml
@@ -730,8 +730,6 @@ entities:
       pos: 0.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 115
     - type: AtmosPipeColor
@@ -743,8 +741,6 @@ entities:
       pos: 0.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 115
     - type: AtmosPipeColor
@@ -766,8 +762,6 @@ entities:
       pos: -1.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 115
     - type: AtmosPipeColor
@@ -779,8 +773,6 @@ entities:
       pos: -1.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 115
     - type: AtmosPipeColor

--- a/Resources/Maps/_Null/Shuttles/Civilian/grisial.yml
+++ b/Resources/Maps/_Null/Shuttles/Civilian/grisial.yml
@@ -1139,8 +1139,6 @@ entities:
       pos: -1.5,11.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 168
   - uid: 156
@@ -1169,8 +1167,6 @@ entities:
       pos: 1.5,10.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 168
   - uid: 180
@@ -1188,8 +1184,6 @@ entities:
       pos: -3.5,11.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 168
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Null/Shuttles/Expedition/crapbucket.yml
+++ b/Resources/Maps/_Null/Shuttles/Expedition/crapbucket.yml
@@ -1027,8 +1027,6 @@ entities:
       pos: 0.5,4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 340
 - proto: FirelockEdge
@@ -1263,8 +1261,6 @@ entities:
       pos: 1.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 340
   - uid: 299
@@ -1321,8 +1317,6 @@ entities:
       pos: -0.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 340
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Null/Shuttles/Expedition/foxhunt.yml
+++ b/Resources/Maps/_Null/Shuttles/Expedition/foxhunt.yml
@@ -654,8 +654,6 @@ entities:
       pos: 2.5,0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 71
   - uid: 162
@@ -675,8 +673,6 @@ entities:
       pos: 3.5,-0.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 71
   - uid: 60

--- a/Resources/Maps/_Null/Shuttles/Expedition/torque.yml
+++ b/Resources/Maps/_Null/Shuttles/Expedition/torque.yml
@@ -4406,8 +4406,6 @@ entities:
       pos: 2.5,34.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4419,8 +4417,6 @@ entities:
       pos: 6.5,36.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4432,8 +4428,6 @@ entities:
       pos: 2.5,39.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4540,8 +4534,6 @@ entities:
       pos: 5.5,34.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4553,8 +4545,6 @@ entities:
       pos: 8.5,34.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4565,8 +4555,6 @@ entities:
       pos: 8.5,38.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4578,8 +4566,6 @@ entities:
       pos: -0.5,35.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4590,8 +4576,6 @@ entities:
       pos: 3.5,39.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
   - uid: 887
@@ -4651,8 +4635,6 @@ entities:
       pos: -2.5,42.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor
@@ -4664,8 +4646,6 @@ entities:
       pos: -5.5,39.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 947
     - type: AtmosPipeColor

--- a/Resources/Maps/_Null/Shuttles/Military/judiciary.yml
+++ b/Resources/Maps/_Null/Shuttles/Military/judiciary.yml
@@ -735,8 +735,6 @@ entities:
       pos: -1.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 594
@@ -746,8 +744,6 @@ entities:
       pos: -0.5,-3.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 595
@@ -757,8 +753,6 @@ entities:
       pos: -4.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 596
@@ -768,8 +762,6 @@ entities:
       pos: -1.5,3.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 597
@@ -779,8 +771,6 @@ entities:
       pos: -1.5,11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 598
@@ -796,8 +786,6 @@ entities:
       pos: -5.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 600
@@ -807,8 +795,6 @@ entities:
       pos: 2.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 609
@@ -817,8 +803,6 @@ entities:
       pos: 1.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: AmeController
@@ -2374,8 +2358,6 @@ entities:
       pos: -2.5,8.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: FirelockGlass
@@ -2386,8 +2368,6 @@ entities:
       pos: -4.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 602
@@ -2396,8 +2376,6 @@ entities:
       pos: -0.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 603
@@ -2406,8 +2384,6 @@ entities:
       pos: 0.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 604
@@ -2416,8 +2392,6 @@ entities:
       pos: -1.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 605
@@ -2426,8 +2400,6 @@ entities:
       pos: -1.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 606
@@ -2436,8 +2408,6 @@ entities:
       pos: -3.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 607
@@ -2446,8 +2416,6 @@ entities:
       pos: 0.5,7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 608
@@ -2456,8 +2424,6 @@ entities:
       pos: 2.5,10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GasOutletInjector
@@ -2895,8 +2861,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 280
@@ -2907,8 +2871,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 299
@@ -2920,8 +2882,6 @@ entities:
     - type: AtmosPipeColor
       color: '#0055CCFF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GasVentScrubber
@@ -2935,8 +2895,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 279
@@ -2947,8 +2905,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
   - uid: 323
@@ -2959,8 +2915,6 @@ entities:
     - type: AtmosPipeColor
       color: '#990000FF'
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 592
 - proto: GravityGeneratorMini

--- a/Resources/Maps/_Null/Shuttles/Salvage/thumpback.yml
+++ b/Resources/Maps/_Null/Shuttles/Salvage/thumpback.yml
@@ -1732,8 +1732,6 @@ entities:
       pos: -0.5,1.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1744,8 +1742,6 @@ entities:
       pos: 0.5,27.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1757,8 +1753,6 @@ entities:
       pos: 1.5,9.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1770,8 +1764,6 @@ entities:
       pos: 1.5,19.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1796,8 +1788,6 @@ entities:
       pos: -1.5,14.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1808,8 +1798,6 @@ entities:
       pos: -0.5,27.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1821,8 +1809,6 @@ entities:
       pos: -1.5,19.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor
@@ -1834,8 +1820,6 @@ entities:
       pos: -0.5,2.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 296
     - type: AtmosPipeColor

--- a/Resources/Maps/_Null/Shuttles/Scrap/montressor.yml
+++ b/Resources/Maps/_Null/Shuttles/Scrap/montressor.yml
@@ -1187,9 +1187,6 @@ entities:
     - type: Transform
       pos: 2.5,13.5
       parent: 1
-    - type: DisposalUnit
-      recentlyEjected:
-      - invalid
 - proto: DrinkBottleRum
   entities:
   - uid: 293


### PR DESCRIPTION
## About the PR
- Fixes an error in the server console caused by invalid entries in ship .yml files. 

## Media
When buying an affected ship there will be errors from the entity_deserializer.
![doesitmattertho](https://github.com/user-attachments/assets/4178dbac-560b-4a64-aaea-520293bbf958)

When selling that ship you get an error for each invalid entry.
![doesitmattertho3](https://github.com/user-attachments/assets/06a651de-3dba-4fd6-a1f5-ff1674ff85d6)

To reproduce the bug, place an air alarm, link it to an air sensor. Delete and replace the air alarm, re-link it to the air sensor. Now when you save or load this grid the entity_deserializer will report the error in the server console. For the disposal unit version of the bug, just place an item inside and eject it.