### PR TITLE
Nourishment: FLT Removal

### DIFF
--- a/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
+++ b/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
@@ -1,41 +1,6190 @@
-# Author Info
-# Github: Bluespace-Storm
-# Discord: Bear
-
-# Shuttle Notes: 
-
-
-- type: vessel
-  id: Nourishment
-  parent: BaseVessel
-  name: UNJ Nourishment
-  description: A top of the line Restaurant Support Vessel. Includes a Vox dining area and space fly-up counter.
-  price: 69000
-  category: Small
-  group: Shipyard
-  shuttlePath: /Maps/_Null/Shuttles/Civilian/nourishment.yml
-  guidebookPage: ShipyardNourishment
-  class:
-  - Civilian
-  engine:
-  - Uranium
-
-- type: gameMap
-  id: Nourishment
-  mapName: 'Nourishment'
-  mapPath: /Maps/_Null/Shuttles/Civilian/nourishment.yml
-  minPlayers: 0
-  stations:
-    Nourishment:
-      stationProto: StandardFrontierVessel
-      components:
-        - type: StationNameSetup
-          mapNameTemplate: 'Nourishment CIV{1}'
-          nameGenerator:
-            !type:NanotrasenNameGenerator
-            prefixCreator: '14'
-        - type: StationJobs
-          availableJobs:
-            Contractor: [ 0, 0 ]
-            Pilot: [ 0, 0 ]
-            Mercenary: [ 0, 0 ]
+meta:
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 06/13/2025 04:46:17
+  entityCount: 814
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
+tilemap:
+  1: Space
+  13: FloorBar
+  14: FloorBlueCircuit
+  11: FloorFreezer
+  3: FloorHull
+  7: FloorKitchen
+  12: FloorLaundry
+  10: FloorRGlass
+  9: FloorShowroom
+  16: FloorSteelOffset
+  4: FloorTechMaint
+  6: FloorTechMaint2
+  8: FloorWhite
+  15: FloorWhiteOffset
+  5: FloorWhitePlastic
+  2: Lattice
+  0: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 1
+    components:
+    - type: MetaData
+      name: Nourishment
+    - type: Transform
+      pos: -0.5416667,-0.5052128
+      parent: invalid
+    - type: MapGrid
+      chunks:
+        0,0:
+          ind: 0,0
+          tiles: BAAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABAAAAAAAAAAAAAAABQAAAAAABQAAAAAABQAAAAAABQAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABgAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAABgAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAABwAAAAAABwAAAAAABwAAAAAABwAAAAAABgAAAAAACAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAAAAAAAAACAAAAAAACAAAAAAACAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAACQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACgAAAAAADwAAAAAACgAAAAAADwAAAAAADwAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        0,-1:
+          ind: 0,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADgAAAAAABAAAAAAABAAAAAAABAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,-1:
+          ind: -1,-1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAAAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAA
+          version: 6
+        -1,0:
+          ind: -1,0
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAABAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAACwAAAAAACwAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAABgAAAAAACwAAAAAACwAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAABgAAAAAABwAAAAAABwAAAAAABwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAwAAAAAAAAAAAAAABwAAAAAABwAAAAAABwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAAAAAAAADAAAAAAADAAAAAAAAAAAAAAABwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAAAAAAAAAAAAAAAAAABgAAAAAAAAAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAwAAAAAABgAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAA
+          version: 6
+        0,1:
+          ind: 0,1
+          tiles: CgAAAAAADwAAAAAACgAAAAAADwAAAAAADwAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAACgAAAAAADwAAAAAACgAAAAAADwAAAAAADwAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAADwAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAEAAAAAAAEAAAAAAAAAAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAABgAAAAAAAAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+        -1,1:
+          ind: -1,1
+          tiles: AQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAADQAAAAAADQAAAAAAAAAAAAAADwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAADQAAAAAADQAAAAAAAAAAAAAADwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAADQAAAAAADQAAAAAAAAAAAAAADwAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAEAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAgAAAAAAAAAAAAAAEAAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAAAAAAAABgAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAA
+          version: 6
+    - type: Broadphase
+    - type: Physics
+      bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+    - type: Fixtures
+      fixtures: {}
+    - type: OccluderTree
+    - type: SpreaderGrid
+    - type: Shuttle
+    - type: GridPathfinding
+    - type: Gravity
+      gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+    - type: DecalGrid
+      chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            112: 0.99681306,14.189952
+            113: 2.996813,14.189952
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            37: -6,14
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            27: 0,21
+            230: -2,15
+            231: 4,15
+            232: 0,21
+        - node:
+            color: '#9B0000FF'
+            id: BotGreyscale
+          decals:
+            229: 3,1
+        - node:
+            color: '#FFFFFFFF'
+            id: BotGreyscale
+          decals:
+            186: 1,1
+            228: -1,1
+        - node:
+            color: '#FFFFFFFF'
+            id: Box
+          decals:
+            1: -1,9
+            238: -1,9
+        - node:
+            color: '#08528DFF'
+            id: BoxGreyscale
+          decals:
+            2: 6,12
+            5: -3,12
+            6: 0,10
+            7: 4,3
+            9: -2,6
+            197: 4,3
+            200: 0,10
+            201: 3,16
+            202: 6,12
+            203: -3,18
+        - node:
+            color: '#145EA8FF'
+            id: BoxGreyscale
+          decals:
+            227: -1,0
+        - node:
+            color: '#9B0000FF'
+            id: BoxGreyscale
+          decals:
+            10: -1,10
+            11: -4,12
+            14: 3,3
+            16: 5,12
+            17: -2,7
+            190: 3,3
+            191: -2,7
+            192: -1,10
+            193: 5,12
+            194: -1,16
+            195: -3,17
+            196: -4,12
+            226: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: BoxGreyscale
+          decals:
+            187: 3,0
+            188: 3,-1
+        - node:
+            color: '#08528DFF'
+            id: BrickBoxOverlay
+          decals:
+            19: 3,0
+        - node:
+            color: '#A72323FF'
+            id: BrickBoxOverlay
+          decals:
+            18: 3,-1
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            92: 4,18
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerNe
+          decals:
+            133: 4,9
+            142: 3,12
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            87: -1,18
+            105: -4,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerNw
+          decals:
+            146: -1,12
+            147: -3,10
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            96: 4,15
+            97: 3,14
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerSe
+          decals:
+            114: 1,20
+            130: 4,6
+            140: 3,11
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteCornerSw
+          decals:
+            115: -1,20
+            150: -3,9
+            151: 0,6
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            66: -1,14
+            67: 1,14
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteInnerNe
+          decals:
+            158: 0,9
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            108: -1,15
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            64: 3,14
+            65: 1,14
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteInnerNw
+          decals:
+            156: -1,10
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            106: 3,15
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            69: 1,18
+            107: -1,18
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteInnerSe
+          decals:
+            157: 0,11
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            62: 1,18
+            63: 3,18
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            159: 0,9
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteLineE
+          decals:
+            93: 4,17
+            94: 4,16
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteLineE
+          decals:
+            46: -1,15
+            47: -1,16
+            48: -1,17
+            59: 1,17
+            60: 1,16
+            61: 1,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteLineE
+          decals:
+            118: 1,21
+            131: 4,7
+            132: 4,8
+            137: 0,10
+            141: 3,12
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteLineN
+          decals:
+            82: -3,15
+            83: -2,15
+            88: 0,18
+            89: 1,18
+            90: 2,18
+            91: 3,18
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteLineN
+          decals:
+            52: 0,14
+            53: 2,14
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteLineN
+          decals:
+            116: 0,21
+            134: 3,9
+            135: 2,9
+            136: 1,9
+            143: 2,12
+            144: 1,12
+            145: 0,12
+            155: -2,10
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteLineS
+          decals:
+            98: 2,14
+            99: 1,14
+            100: 0,14
+            101: -1,14
+            102: -2,14
+            103: -3,14
+            110: -4,14
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteLineS
+          decals:
+            54: 0,18
+            55: 2,18
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteLineS
+          decals:
+            117: 0,20
+            138: 1,11
+            139: 2,11
+            153: -1,9
+            154: -2,9
+            160: 1,6
+            161: 2,6
+            162: 3,6
+        - node:
+            color: '#00BEBEFF'
+            id: BrickTileWhiteLineW
+          decals:
+            84: -1,16
+            85: -1,17
+        - node:
+            color: '#4593A5FF'
+            id: BrickTileWhiteLineW
+          decals:
+            49: 3,15
+            50: 3,16
+            51: 3,17
+            56: 1,17
+            57: 1,16
+            58: 1,15
+        - node:
+            color: '#FFFFFFFF'
+            id: BrickTileWhiteLineW
+          decals:
+            119: -1,21
+            148: -1,11
+            149: 0,7
+            152: 0,8
+        - node:
+            color: '#FFFFFFFF'
+            id: Caution
+          decals:
+            23: -0.9873803,21.557524
+            24: 1.0126197,21.557524
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            233: -5,7
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale
+          decals:
+            168: 6,13
+        - node:
+            color: '#3D8C40CC'
+            id: HalfTileOverlayGreyscale
+          decals:
+            128: 3,4
+            129: 4,4
+        - node:
+            color: '#334E6DC8'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            167: 6,12
+        - node:
+            color: '#3D8C40CC'
+            id: HalfTileOverlayGreyscale180
+          decals:
+            126: 3,3
+            127: 4,3
+        - node:
+            color: '#5FA1E7FF'
+            id: HalfTileOverlayGreyscale270
+          decals:
+            207: 1,-1
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: LoadingAreaGreyscale
+          decals:
+            36: -5,9
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: MarkupRectangle1x2
+          decals:
+            210: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: MarkupRectangle1x2
+          decals:
+            208: 0,0
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: MarkupRectangle1x2
+          decals:
+            209: -1,-1
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: MarkupSquareQuater
+          decals:
+            211: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: MarkupSquareQuater
+          decals:
+            212: -1,0
+        - node:
+            color: '#A72323FF'
+            id: MiniTileCornerOverlayNE
+          decals:
+            79: -3,18
+        - node:
+            color: '#A72323FF'
+            id: MiniTileCornerOverlayNW
+          decals:
+            78: -4,18
+        - node:
+            color: '#A72323FF'
+            id: MiniTileCornerOverlaySE
+          decals:
+            74: -3,16
+        - node:
+            color: '#A72323FF'
+            id: MiniTileCornerOverlaySW
+          decals:
+            75: -4,16
+        - node:
+            color: '#A72323FF'
+            id: MiniTileLineOverlayE
+          decals:
+            76: -3,17
+        - node:
+            color: '#A72323FF'
+            id: MiniTileLineOverlayW
+          decals:
+            77: -4,17
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: StandClear
+          decals:
+            20: -4,7
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale
+          decals:
+            164: 5,13
+        - node:
+            color: '#3D8C40CC'
+            id: ThreeQuarterTileOverlayGreyscale
+          decals:
+            122: 2,4
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale180
+          decals:
+            163: 7,12
+        - node:
+            color: '#3D8C40CC'
+            id: ThreeQuarterTileOverlayGreyscale180
+          decals:
+            123: 5,3
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale270
+          decals:
+            166: 5,12
+        - node:
+            color: '#3D8C40CC'
+            id: ThreeQuarterTileOverlayGreyscale270
+          decals:
+            125: 2,3
+        - node:
+            color: '#334E6DC8'
+            id: ThreeQuarterTileOverlayGreyscale90
+          decals:
+            165: 7,13
+        - node:
+            color: '#3D8C40CC'
+            id: ThreeQuarterTileOverlayGreyscale90
+          decals:
+            124: 5,4
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNE
+          decals:
+            222: 0.49785084,-0.49807858
+            240: 0.5008986,-0.49677354
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerNW
+          decals:
+            221: -0.5125659,-0.49807858
+            239: -0.5098081,-0.49677354
+        - node:
+            color: '#5FA1E7FF'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            217: -1,0
+        - node:
+            color: '#5FA1E7FF'
+            id: WarnCornerSmallGreyscaleSW
+          decals:
+            216: 1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnFullGreyscale
+          decals:
+            177: -1,3
+            178: -2,3
+            179: -3,3
+            180: -4,3
+            181: -5,4
+            184: -5,3
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineE
+          decals:
+            224: 0.49785084,-1.0088501
+            234: 2,-1
+            235: 2,0
+            236: 2,1
+        - node:
+            color: '#5FA1E7FF'
+            id: WarnLineGreyscaleE
+          decals:
+            213: -1,-1
+        - node:
+            color: '#5FA1E7FF'
+            id: WarnLineGreyscaleS
+          decals:
+            215: 0,0
+        - node:
+            color: '#5FA1E7FF'
+            id: WarnLineGreyscaleW
+          decals:
+            214: 1,-1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineN
+          decals:
+            80: -4,16
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineS
+          decals:
+            111: -4,14
+            218: -1,-1
+            219: -1,0
+            220: -1,1
+            225: -0.5125659,-1.0192744
+            237: -1,0
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineW
+          decals:
+            34: -1,21
+            35: 1,21
+            120: -1,21
+            121: 1,21
+            223: -0.022982538,-0.49807858
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#32CD32FF'
+            id: nay
+          decals:
+            21: -1,13
+    - type: GridAtmosphere
+      version: 2
+      data:
+        tiles:
+          0,0:
+            0: 53759
+          0,-1:
+            0: 61576
+            1: 68
+          -1,0:
+            0: 61678
+          0,1:
+            0: 65437
+          -1,1:
+            0: 2063
+            2: 26112
+          0,2:
+            0: 61951
+          -1,2:
+            0: 36592
+          0,3:
+            0: 65519
+          -1,3:
+            0: 65451
+          0,4:
+            0: 16383
+          1,0:
+            0: 12288
+            1: 2
+            3: 64
+          1,1:
+            0: 4355
+            1: 25600
+          1,2:
+            0: 17
+            1: 546
+            3: 3268
+          1,3:
+            0: 4335
+            1: 49152
+          1,4:
+            0: 273
+            1: 52428
+          1,-1:
+            1: 9301
+            0: 34
+          -1,-1:
+            0: 57378
+            1: 85
+          0,-2:
+            1: 19532
+            0: 32896
+          1,-2:
+            1: 22343
+            0: 8240
+          -2,-2:
+            1: 19532
+            0: 32896
+          -2,-1:
+            1: 33860
+            0: 136
+          -1,-2:
+            1: 22343
+            0: 8240
+          -2,0:
+            1: 8
+            3: 64
+            0: 32768
+          -2,1:
+            1: 9728
+            3: 51200
+            0: 8
+          -2,2:
+            1: 8738
+            3: 19660
+          -2,3:
+            1: 25122
+            3: 1092
+            0: 2048
+          -2,4:
+            1: 26214
+          -1,4:
+            4: 819
+            0: 34952
+          0,5:
+            0: 563
+            1: 136
+          -1,5:
+            0: 2184
+            1: 51
+          1,5:
+            1: 127
+          -2,5:
+            1: 206
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          immutable: True
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 235
+          moles:
+          - 27.225372
+          - 102.419266
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 103.92799
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+    - type: GasTileOverlay
+    - type: RadiationGridResistance
+    - type: BecomesStation
+      id: Nourishment
+- proto: AirAlarm
+  entities:
+  - uid: 98
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 426
+  - uid: 151
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,2.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 344
+      - 345
+      - 427
+  - uid: 432
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,12.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 337
+      - 336
+      - 428
+      - 430
+      - 425
+      - 426
+      - 427
+  - uid: 433
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 429
+      - 428
+      - 350
+      - 349
+      - 436
+      - 437
+      - 438
+      - 787
+- proto: AirAlarmFreezer
+  entities:
+  - uid: 814
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+- proto: AirAlarmVox
+  entities:
+  - uid: 255
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 256
+      - 257
+      - 436
+- proto: Airlock
+  entities:
+  - uid: 325
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,13.5
+      parent: 1
+- proto: AirlockCommand
+  entities:
+  - uid: 326
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,12.5
+      parent: 1
+- proto: AirlockEngineering
+  entities:
+  - uid: 162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+- proto: AirlockFreezer
+  entities:
+  - uid: 152
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+- proto: AirlockGlass
+  entities:
+  - uid: 641
+    components:
+    - type: Transform
+      pos: -4.5,14.5
+      parent: 1
+- proto: AirlockGlassShuttle
+  entities:
+  - uid: 259
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,22.5
+      parent: 1
+  - uid: 284
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,22.5
+      parent: 1
+- proto: AirlockHatchMaintenance
+  entities:
+  - uid: 632
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,8.5
+      parent: 1
+- proto: AirlockHydroponicsGlass
+  entities:
+  - uid: 165
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+- proto: APCBasic
+  entities:
+  - uid: 134
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 444
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,20.5
+      parent: 1
+- proto: AtmosDeviceFanDirectional
+  entities:
+  - uid: 117
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 119
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 249
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 642
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 647
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+  - uid: 780
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,22.5
+      parent: 1
+  - uid: 811
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,22.5
+      parent: 1
+- proto: AtmosFixBlockerMarker
+  entities:
+  - uid: 26
+    components:
+    - type: Transform
+      pos: 6.5,8.5
+      parent: 1
+  - uid: 35
+    components:
+    - type: Transform
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 36
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+  - uid: 37
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 1
+  - uid: 39
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 7.5,20.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 7.5,18.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 7.5,19.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -6.5,19.5
+      parent: 1
+  - uid: 103
+    components:
+    - type: Transform
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 105
+    components:
+    - type: Transform
+      pos: -4.5,9.5
+      parent: 1
+  - uid: 107
+    components:
+    - type: Transform
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 130
+    components:
+    - type: Transform
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 142
+    components:
+    - type: Transform
+      pos: -5.5,8.5
+      parent: 1
+  - uid: 153
+    components:
+    - type: Transform
+      pos: -6.5,20.5
+      parent: 1
+  - uid: 168
+    components:
+    - type: Transform
+      pos: -4.5,7.5
+      parent: 1
+  - uid: 200
+    components:
+    - type: Transform
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 222
+    components:
+    - type: Transform
+      pos: -5.5,11.5
+      parent: 1
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -5.5,13.5
+      parent: 1
+  - uid: 312
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 314
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 537
+    components:
+    - type: Transform
+      pos: -5.5,7.5
+      parent: 1
+  - uid: 554
+    components:
+    - type: Transform
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 555
+    components:
+    - type: Transform
+      pos: -3.5,21.5
+      parent: 1
+  - uid: 556
+    components:
+    - type: Transform
+      pos: -4.5,21.5
+      parent: 1
+  - uid: 557
+    components:
+    - type: Transform
+      pos: -5.5,21.5
+      parent: 1
+  - uid: 558
+    components:
+    - type: Transform
+      pos: -5.5,20.5
+      parent: 1
+  - uid: 560
+    components:
+    - type: Transform
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 561
+    components:
+    - type: Transform
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 562
+    components:
+    - type: Transform
+      pos: 5.5,21.5
+      parent: 1
+  - uid: 563
+    components:
+    - type: Transform
+      pos: 6.5,21.5
+      parent: 1
+  - uid: 564
+    components:
+    - type: Transform
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 565
+    components:
+    - type: Transform
+      pos: -4.5,10.5
+      parent: 1
+  - uid: 568
+    components:
+    - type: Transform
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 573
+    components:
+    - type: Transform
+      pos: -5.5,10.5
+      parent: 1
+  - uid: 576
+    components:
+    - type: Transform
+      pos: -5.5,9.5
+      parent: 1
+  - uid: 577
+    components:
+    - type: Transform
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 581
+    components:
+    - type: Transform
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 600
+    components:
+    - type: Transform
+      pos: -5.5,12.5
+      parent: 1
+  - uid: 605
+    components:
+    - type: Transform
+      pos: -5.5,14.5
+      parent: 1
+  - uid: 635
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: 5.5,-0.5
+      parent: 1
+  - uid: 689
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 735
+    components:
+    - type: Transform
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 746
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 7.5,16.5
+      parent: 1
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 7.5,15.5
+      parent: 1
+- proto: AtmosFixFreezerMarker
+  entities:
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -3.5,7.5
+      parent: 1
+  - uid: 752
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 753
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+- proto: AtmosFixVoxMarker
+  entities:
+  - uid: 548
+    components:
+    - type: Transform
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 549
+    components:
+    - type: Transform
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 550
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 551
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 552
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 1
+  - uid: 553
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 1
+- proto: BlastDoor
+  entities:
+  - uid: 172
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,7.5
+      parent: 1
+- proto: BoxPaper
+  entities:
+  - uid: 813
+    components:
+    - type: Transform
+      pos: -1.7967055,10.715487
+      parent: 1
+- proto: Bucket
+  entities:
+  - uid: 812
+    components:
+    - type: Transform
+      pos: 3.1273453,3.9119935
+      parent: 1
+- proto: ButchCleaver
+  entities:
+  - uid: 791
+    components:
+    - type: Transform
+      pos: 3.4178784,7.5714784
+      parent: 1
+- proto: ButtonFrameCaution
+  entities:
+  - uid: 173
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 789
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+- proto: ButtonFrameCautionSecurity
+  entities:
+  - uid: 807
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,11.5
+      parent: 1
+- proto: CableApcExtension
+  entities:
+  - uid: 27
+    components:
+    - type: Transform
+      pos: 3.5,8.5
+      parent: 1
+  - uid: 31
+    components:
+    - type: Transform
+      pos: 4.5,8.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: 3.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+  - uid: 472
+    components:
+    - type: Transform
+      pos: -1.5,20.5
+      parent: 1
+  - uid: 473
+    components:
+    - type: Transform
+      pos: -1.5,19.5
+      parent: 1
+  - uid: 474
+    components:
+    - type: Transform
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 475
+    components:
+    - type: Transform
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 476
+    components:
+    - type: Transform
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 477
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 478
+    components:
+    - type: Transform
+      pos: -0.5,19.5
+      parent: 1
+  - uid: 479
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 480
+    components:
+    - type: Transform
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 481
+    components:
+    - type: Transform
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 482
+    components:
+    - type: Transform
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 483
+    components:
+    - type: Transform
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 484
+    components:
+    - type: Transform
+      pos: 5.5,19.5
+      parent: 1
+  - uid: 485
+    components:
+    - type: Transform
+      pos: 3.5,18.5
+      parent: 1
+  - uid: 486
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 1
+  - uid: 487
+    components:
+    - type: Transform
+      pos: 3.5,16.5
+      parent: 1
+  - uid: 488
+    components:
+    - type: Transform
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -0.5,17.5
+      parent: 1
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -0.5,18.5
+      parent: 1
+  - uid: 491
+    components:
+    - type: Transform
+      pos: -0.5,16.5
+      parent: 1
+  - uid: 492
+    components:
+    - type: Transform
+      pos: -0.5,15.5
+      parent: 1
+  - uid: 493
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+  - uid: 494
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 495
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 496
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 497
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 498
+    components:
+    - type: Transform
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 499
+    components:
+    - type: Transform
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 500
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 501
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 502
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 503
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 504
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 505
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 506
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 507
+    components:
+    - type: Transform
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 508
+    components:
+    - type: Transform
+      pos: -1.5,10.5
+      parent: 1
+  - uid: 509
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+  - uid: 510
+    components:
+    - type: Transform
+      pos: 2.5,12.5
+      parent: 1
+  - uid: 511
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+  - uid: 512
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 513
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+  - uid: 514
+    components:
+    - type: Transform
+      pos: 2.5,8.5
+      parent: 1
+  - uid: 515
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 516
+    components:
+    - type: Transform
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 518
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 519
+    components:
+    - type: Transform
+      pos: 2.5,6.5
+      parent: 1
+  - uid: 520
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 521
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 523
+    components:
+    - type: Transform
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 524
+    components:
+    - type: Transform
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 525
+    components:
+    - type: Transform
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 526
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 527
+    components:
+    - type: Transform
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 528
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 529
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 530
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+  - uid: 531
+    components:
+    - type: Transform
+      pos: -3.5,4.5
+      parent: 1
+  - uid: 532
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 533
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+  - uid: 534
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 535
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 536
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 540
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 546
+    components:
+    - type: Transform
+      pos: 3.5,1.5
+      parent: 1
+  - uid: 547
+    components:
+    - type: Transform
+      pos: 3.5,0.5
+      parent: 1
+  - uid: 692
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 693
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 694
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 695
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 696
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 697
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 698
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 699
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 700
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 701
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 702
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 703
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 704
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 705
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 706
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 707
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 708
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 709
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 710
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 711
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 723
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 93
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 132
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 589
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 725
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+- proto: CableMV
+  entities:
+  - uid: 449
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 450
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 452
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+  - uid: 453
+    components:
+    - type: Transform
+      pos: -0.5,4.5
+      parent: 1
+  - uid: 454
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 455
+    components:
+    - type: Transform
+      pos: -0.5,6.5
+      parent: 1
+  - uid: 456
+    components:
+    - type: Transform
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 457
+    components:
+    - type: Transform
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 458
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+  - uid: 459
+    components:
+    - type: Transform
+      pos: -0.5,10.5
+      parent: 1
+  - uid: 460
+    components:
+    - type: Transform
+      pos: -0.5,12.5
+      parent: 1
+  - uid: 461
+    components:
+    - type: Transform
+      pos: -0.5,13.5
+      parent: 1
+  - uid: 462
+    components:
+    - type: Transform
+      pos: -0.5,11.5
+      parent: 1
+  - uid: 463
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 464
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 465
+    components:
+    - type: Transform
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 466
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+  - uid: 467
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 468
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 469
+    components:
+    - type: Transform
+      pos: -1.5,18.5
+      parent: 1
+  - uid: 470
+    components:
+    - type: Transform
+      pos: -1.5,19.5
+      parent: 1
+  - uid: 471
+    components:
+    - type: Transform
+      pos: -1.5,20.5
+      parent: 1
+  - uid: 737
+    components:
+    - type: Transform
+      pos: -1.5,5.5
+      parent: 1
+- proto: CableTerminal
+  entities:
+  - uid: 84
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
+      parent: 1
+- proto: Catwalk
+  entities:
+  - uid: 423
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 727
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,1.5
+      parent: 1
+  - uid: 728
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,0.5
+      parent: 1
+  - uid: 729
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 730
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 731
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,-0.5
+      parent: 1
+  - uid: 733
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,7.5
+      parent: 1
+  - uid: 757
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,7.5
+      parent: 1
+  - uid: 758
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 1
+  - uid: 759
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,9.5
+      parent: 1
+  - uid: 805
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,8.5
+      parent: 1
+- proto: ChairPilotSeat
+  entities:
+  - uid: 329
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,12.5
+      parent: 1
+- proto: ClosetChefFilled
+  entities:
+  - uid: 584
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 1
+- proto: ClosetWallO2N2Filled
+  entities:
+  - uid: 44
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,21.5
+      parent: 1
+  - uid: 448
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 740
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,15.5
+      parent: 1
+- proto: ClothingEyesGlassesMeson
+  entities:
+  - uid: 538
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: ClothingHeadHatChef
+  entities:
+  - uid: 197
+    components:
+    - type: Transform
+      pos: 3.1792252,7.641388
+      parent: 1
+- proto: ClothingOuterApronChef
+  entities:
+  - uid: 198
+    components:
+    - type: Transform
+      pos: 3.1490266,7.6754804
+      parent: 1
+- proto: ClothingOuterWinterChef
+  entities:
+  - uid: 196
+    components:
+    - type: Transform
+      pos: 2.54234,6.4055095
+      parent: 1
+- proto: ComputerAtmosMonitoring
+  entities:
+  - uid: 588
+    components:
+    - type: Transform
+      pos: 1.5,1.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerPowerMonitoring
+  entities:
+  - uid: 517
+    components:
+    - type: Transform
+      pos: -0.5,1.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerTabletopShuttle
+  entities:
+  - uid: 330
+    components:
+    - type: Transform
+      pos: 7.5,13.5
+      parent: 1
+    - type: ShuttleConsoleLock
+      locked: False
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+    - type: DeviceLinkSource
+      linkedPorts: {}
+      lastSignals: {}
+      ports:
+      - device-button-1
+      - device-button-2
+      - device-button-3
+      - device-button-4
+      - device-button-5
+      - device-button-6
+      - device-button-7
+      - device-button-8
+- proto: ComputerTabletopStationRecords
+  entities:
+  - uid: 208
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerTabletopSurveillanceCameraMonitor
+  entities:
+  - uid: 141
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerWallmountRadar
+  entities:
+  - uid: 78
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,19.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: ComputerWallmountWithdrawBankATM
+  entities:
+  - uid: 189
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+  - uid: 779
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+    - type: ApcPowerReceiver
+      powerLoad: 5
+    - type: Battery
+      startingCharge: 0
+- proto: CondimentCupDispenser10
+  entities:
+  - uid: 271
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.503967,16.777992
+      parent: 1
+  - uid: 272
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5143833,16.4757
+      parent: 1
+- proto: CondimentDispenser
+  entities:
+  - uid: 269
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,17.5
+      parent: 1
+- proto: CrateHydroponicsSeeds
+  entities:
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 2.5,3.5
+      parent: 1
+- proto: CrateTrashCart
+  entities:
+  - uid: 634
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+- proto: DefibrillatorCabinetFilled
+  entities:
+  - uid: 424
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,18.5
+      parent: 1
+- proto: DisposalBend
+  entities:
+  - uid: 603
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+  - uid: 620
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+- proto: DisposalJunction
+  entities:
+  - uid: 616
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+- proto: DisposalJunctionFlipped
+  entities:
+  - uid: 193
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+  - uid: 611
+    components:
+    - type: Transform
+      pos: 0.5,15.5
+      parent: 1
+- proto: DisposalPipe
+  entities:
+  - uid: 604
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+  - uid: 606
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 1
+  - uid: 607
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 1
+  - uid: 608
+    components:
+    - type: Transform
+      pos: 0.5,18.5
+      parent: 1
+  - uid: 609
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 610
+    components:
+    - type: Transform
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 612
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+  - uid: 613
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,15.5
+      parent: 1
+  - uid: 614
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 615
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,15.5
+      parent: 1
+  - uid: 617
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 618
+    components:
+    - type: Transform
+      pos: 0.5,12.5
+      parent: 1
+  - uid: 619
+    components:
+    - type: Transform
+      pos: 0.5,11.5
+      parent: 1
+  - uid: 621
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 622
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 623
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 624
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+  - uid: 625
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,10.5
+      parent: 1
+- proto: DisposalTrunk
+  entities:
+  - uid: 24
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 310
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 601
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+  - uid: 626
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,10.5
+      parent: 1
+  - uid: 739
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+- proto: DisposalUnit
+  entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 335
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 738
+    components:
+    - type: Transform
+      pos: -1.5,15.5
+      parent: 1
+- proto: ExtinguisherCabinetFilled
+  entities:
+  - uid: 440
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 441
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,17.5
+      parent: 1
+- proto: FaxMachineShip
+  entities:
+  - uid: 815
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+- proto: FireAlarm
+  entities:
+  - uid: 203
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 426
+      - 427
+  - uid: 434
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,20.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 437
+      - 438
+      - 428
+      - 429
+      - 436
+      - 787
+  - uid: 435
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,7.5
+      parent: 1
+    - type: DeviceList
+      devices:
+      - 428
+      - 438
+      - 437
+      - 430
+      - 425
+      - 427
+      - 426
+- proto: Firelock
+  entities:
+  - uid: 425
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,6.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+      - 435
+  - uid: 426
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+      - 98
+      - 435
+      - 203
+  - uid: 427
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,5.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+      - 151
+      - 435
+      - 203
+  - uid: 428
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 432
+      - 434
+      - 435
+  - uid: 429
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 434
+  - uid: 430
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,12.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+      - 435
+  - uid: 431
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 787
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,14.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 434
+- proto: FirelockEdge
+  entities:
+  - uid: 436
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 255
+      - 434
+  - uid: 437
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 434
+      - 435
+  - uid: 438
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+      - 434
+      - 435
+- proto: FloorDrain
+  entities:
+  - uid: 157
+    components:
+    - type: Transform
+      pos: -2.5,7.5
+      parent: 1
+    - type: Fixtures
+      fixtures: {}
+- proto: GasMixerOn
+  entities:
+  - uid: 79
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,-0.5
+      parent: 1
+    - type: GasMixer
+      inletTwoConcentration: 0.20999998
+      inletOneConcentration: 0.79
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPassiveGate
+  entities:
+  - uid: 234
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+- proto: GasPassiveVent
+  entities:
+  - uid: 732
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeBend
+  entities:
+  - uid: 83
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 89
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 95
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 348
+    components:
+    - type: Transform
+      pos: 0.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 354
+    components:
+    - type: Transform
+      pos: 2.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 360
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 362
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 368
+    components:
+    - type: Transform
+      pos: 6.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 384
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 388
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 389
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 390
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 396
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 400
+    components:
+    - type: Transform
+      pos: 3.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 4.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 410
+    components:
+    - type: Transform
+      pos: 1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 416
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 417
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 418
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 591
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+  - uid: 592
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+  - uid: 724
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeFourway
+  entities:
+  - uid: 593
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+- proto: GasPipeSensor
+  entities:
+  - uid: 212
+    components:
+    - type: MetaData
+      name: gas pipe sensor (Freezer)
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+    - type: Label
+      currentLabel: Freezer
+    - type: NameModifier
+      baseName: gas pipe sensor
+- proto: GasPipeSensorDistribution
+  entities:
+  - uid: 94
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPipeSensorWaste
+  entities:
+  - uid: 111
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasPipeStraight
+  entities:
+  - uid: 86
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 340
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 346
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 347
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 351
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 352
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 353
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,18.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 355
+    components:
+    - type: Transform
+      pos: 2.5,17.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 357
+    components:
+    - type: Transform
+      pos: 2.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 359
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 361
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 363
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 364
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 365
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 366
+    components:
+    - type: Transform
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 369
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 370
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 371
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 374
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 375
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 376
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 377
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 378
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 379
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 380
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 381
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 383
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 385
+    components:
+    - type: Transform
+      pos: 1.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 386
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 393
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 398
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 399
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 401
+    components:
+    - type: Transform
+      pos: 3.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 404
+    components:
+    - type: Transform
+      pos: 0.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 406
+    components:
+    - type: Transform
+      pos: 0.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 407
+    components:
+    - type: Transform
+      pos: 0.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 408
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 409
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 411
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 412
+    components:
+    - type: Transform
+      pos: 1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 413
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 414
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 415
+    components:
+    - type: Transform
+      pos: 1.5,3.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 0.5,7.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 420
+    components:
+    - type: Transform
+      pos: 0.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 594
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+- proto: GasPipeTJunction
+  entities:
+  - uid: 55
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 57
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 90
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 113
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 339
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 367
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 372
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,14.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 373
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 391
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,10.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 392
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,8.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 395
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 596
+    components:
+    - type: Transform
+      pos: -2.5,4.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+- proto: GasPort
+  entities:
+  - uid: 43
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 136
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasPressurePumpOnMax
+  entities:
+  - uid: 75
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,1.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasThermoMachineFreezerEnabled
+  entities:
+  - uid: 443
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+    - type: GasThermoMachine
+      targetTemperature: 200
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+- proto: GasVentPump
+  entities:
+  - uid: 56
+    components:
+    - type: Transform
+      pos: -1.5,6.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#6EF3F5FF'
+  - uid: 88
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 320
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 337
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 341
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 344
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 151
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 350
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentPumpVox
+  entities:
+  - uid: 257
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,18.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 255
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+- proto: GasVentScrubber
+  entities:
+  - uid: 112
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 336
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -0.5,10.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 432
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 338
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 342
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,12.5
+      parent: 1
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 345
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,3.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 151
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 349
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,16.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 433
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasVentScrubberFreezer
+  entities:
+  - uid: 155
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GasVentScrubberVox
+  entities:
+  - uid: 256
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 1
+    - type: DeviceNetwork
+      deviceLists:
+      - 255
+    - type: AtmosPipeColor
+      color: '#990000FF'
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 439
+    components:
+    - type: Transform
+      pos: -3.5,3.5
+      parent: 1
+- proto: Grille
+  entities:
+  - uid: 51
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,16.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,17.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: -1.5,-6.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 2.5,-6.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,-3.5
+      parent: 1
+  - uid: 139
+    components:
+    - type: Transform
+      pos: -6.5,19.5
+      parent: 1
+  - uid: 147
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 148
+    components:
+    - type: Transform
+      pos: 6.5,3.5
+      parent: 1
+  - uid: 217
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 235
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,18.5
+      parent: 1
+  - uid: 251
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 253
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 285
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 286
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 287
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 288
+    components:
+    - type: Transform
+      pos: -5.5,-5.5
+      parent: 1
+  - uid: 291
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 292
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 299
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 300
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,21.5
+      parent: 1
+  - uid: 301
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,21.5
+      parent: 1
+  - uid: 302
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,20.5
+      parent: 1
+  - uid: 303
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 304
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,21.5
+      parent: 1
+  - uid: 305
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,21.5
+      parent: 1
+  - uid: 306
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,20.5
+      parent: 1
+  - uid: 308
+    components:
+    - type: Transform
+      pos: 2.5,-2.5
+      parent: 1
+  - uid: 397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 405
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 539
+    components:
+    - type: Transform
+      pos: -1.5,-4.5
+      parent: 1
+  - uid: 541
+    components:
+    - type: Transform
+      pos: -1.5,-5.5
+      parent: 1
+  - uid: 542
+    components:
+    - type: Transform
+      pos: -5.5,-6.5
+      parent: 1
+  - uid: 543
+    components:
+    - type: Transform
+      pos: -5.5,-2.5
+      parent: 1
+  - uid: 544
+    components:
+    - type: Transform
+      pos: 6.5,-2.5
+      parent: 1
+  - uid: 545
+    components:
+    - type: Transform
+      pos: 6.5,-4.5
+      parent: 1
+  - uid: 566
+    components:
+    - type: Transform
+      pos: -5.5,-3.5
+      parent: 1
+  - uid: 569
+    components:
+    - type: Transform
+      pos: 2.5,-5.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: 2.5,-3.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 2.5,-4.5
+      parent: 1
+  - uid: 574
+    components:
+    - type: Transform
+      pos: -5.5,-4.5
+      parent: 1
+  - uid: 575
+    components:
+    - type: Transform
+      pos: -1.5,-2.5
+      parent: 1
+  - uid: 639
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,18.5
+      parent: 1
+  - uid: 643
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,18.5
+      parent: 1
+  - uid: 644
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,19.5
+      parent: 1
+  - uid: 649
+    components:
+    - type: Transform
+      pos: 6.5,-5.5
+      parent: 1
+  - uid: 650
+    components:
+    - type: Transform
+      pos: 6.5,-6.5
+      parent: 1
+  - uid: 675
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-7.5
+      parent: 1
+  - uid: 676
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,-7.5
+      parent: 1
+  - uid: 677
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-7.5
+      parent: 1
+  - uid: 678
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,-7.5
+      parent: 1
+  - uid: 679
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,-7.5
+      parent: 1
+  - uid: 680
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-7.5
+      parent: 1
+  - uid: 741
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,17.5
+      parent: 1
+  - uid: 742
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 743
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,16.5
+      parent: 1
+- proto: GrilleDiagonal
+  entities:
+  - uid: 276
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 289
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,-7.5
+      parent: 1
+  - uid: 307
+    components:
+    - type: Transform
+      pos: -5.5,21.5
+      parent: 1
+  - uid: 309
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,21.5
+      parent: 1
+  - uid: 442
+    components:
+    - type: Transform
+      pos: -6.5,17.5
+      parent: 1
+  - uid: 637
+    components:
+    - type: Transform
+      pos: -6.5,20.5
+      parent: 1
+  - uid: 638
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,18.5
+      parent: 1
+  - uid: 645
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,20.5
+      parent: 1
+  - uid: 646
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,18.5
+      parent: 1
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -5.5,-1.5
+      parent: 1
+  - uid: 670
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,-7.5
+      parent: 1
+  - uid: 671
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-7.5
+      parent: 1
+  - uid: 673
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,-7.5
+      parent: 1
+  - uid: 674
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-1.5
+      parent: 1
+  - uid: 744
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,17.5
+      parent: 1
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,15.5
+      parent: 1
+- proto: Gyroscope
+  entities:
+  - uid: 58
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,3.5
+      parent: 1
+- proto: HandLabeler
+  entities:
+  - uid: 421
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.050557,7.5198054
+      parent: 1
+    - type: HandLabeler
+      assignedLabel: Cut Engines
+- proto: hydroponicsTray
+  entities:
+  - uid: 145
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,4.5
+      parent: 1
+  - uid: 146
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,3.5
+      parent: 1
+- proto: KitchenAssembler
+  entities:
+  - uid: 154
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+- proto: KitchenDeepFryer
+  entities:
+  - uid: 166
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 1
+- proto: KitchenElectricRange
+  entities:
+  - uid: 167
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 1
+- proto: KitchenKnife
+  entities:
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 3.3345451,7.5714784
+      parent: 1
+- proto: KitchenMicrowave
+  entities:
+  - uid: 171
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+- proto: KitchenReagentGrinder
+  entities:
+  - uid: 169
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+- proto: KitchenSpike
+  entities:
+  - uid: 97
+    components:
+    - type: Transform
+      pos: -2.5,6.5
+      parent: 1
+- proto: LockerWallColorEngineer
+  entities:
+  - uid: 64
+    components:
+    - type: Transform
+      pos: -2.5,5.5
+      parent: 1
+    - type: ContainerContainer
+      containers:
+        entity_storage: !type:Container
+          showEnts: False
+          occludes: True
+          ents:
+          - 538
+          - 65
+        paper_label: !type:ContainerSlot
+          showEnts: False
+          occludes: True
+          ent: null
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.8856695
+        - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: LockerWallColorGenericGreen
+  entities:
+  - uid: 595
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,10.5
+      parent: 1
+- proto: LockerWallColorHydroponicsFilled
+  entities:
+  - uid: 143
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+    - type: EntityStorage
+      air:
+        volume: 200
+        immutable: False
+        temperature: 293.14923
+        moles:
+        - 1.7459903
+        - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+        - 0
+- proto: LockerWallEVAColorServiceWorkerFilled
+  entities:
+  - uid: 59
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 109
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,11.5
+      parent: 1
+- proto: LockerWallMaterialsFuelUraniumFilled2
+  entities:
+  - uid: 87
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,0.5
+      parent: 1
+- proto: NapkinDrum5
+  entities:
+  - uid: 268
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.441467,18.602177
+      parent: 1
+  - uid: 270
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.472717,18.216492
+      parent: 1
+- proto: NFHolopadShip
+  entities:
+  - uid: 786
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 1
+- proto: NFSignDock
+  entities:
+  - uid: 331
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,22.5
+      parent: 1
+  - uid: 332
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,22.5
+      parent: 1
+- proto: NitrogenCanister
+  entities:
+  - uid: 422
+    components:
+    - type: Transform
+      anchored: True
+      pos: 3.5,-0.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: OxygenCanister
+  entities:
+  - uid: 522
+    components:
+    - type: Transform
+      anchored: True
+      pos: 3.5,0.5
+      parent: 1
+    - type: Physics
+      bodyType: Static
+- proto: PortableGeneratorSuperPacmanShuttle
+  entities:
+  - uid: 447
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 590
+    components:
+    - type: Transform
+      pos: -2.5,-0.5
+      parent: 1
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 446
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 1
+- proto: Poweredlight
+  entities:
+  - uid: 772
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,15.5
+      parent: 1
+  - uid: 773
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,14.5
+      parent: 1
+  - uid: 774
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 1
+  - uid: 792
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,3.5
+      parent: 1
+  - uid: 794
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,-0.5
+      parent: 1
+  - uid: 795
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 796
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,4.5
+      parent: 1
+  - uid: 799
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 800
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,10.5
+      parent: 1
+  - uid: 801
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,9.5
+      parent: 1
+- proto: PoweredlightBlue
+  entities:
+  - uid: 681
+    components:
+    - type: Transform
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 682
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 683
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 684
+    components:
+    - type: Transform
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 797
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+- proto: PoweredlightExterior
+  entities:
+  - uid: 293
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,8.5
+      parent: 1
+  - uid: 295
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 1
+  - uid: 296
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 297
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,21.5
+      parent: 1
+  - uid: 298
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,21.5
+      parent: 1
+  - uid: 627
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 6.5,7.5
+      parent: 1
+- proto: PoweredlightRed
+  entities:
+  - uid: 559
+    components:
+    - type: Transform
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 690
+    components:
+    - type: Transform
+      pos: -4.5,-2.5
+      parent: 1
+  - uid: 691
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-4.5
+      parent: 1
+- proto: PoweredSmallLight
+  entities:
+  - uid: 771
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 1
+  - uid: 793
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,7.5
+      parent: 1
+  - uid: 798
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,12.5
+      parent: 1
+- proto: Rack
+  entities:
+  - uid: 114
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 1
+- proto: Railing
+  entities:
+  - uid: 311
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 313
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 760
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,11.5
+      parent: 1
+  - uid: 761
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 763
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -5.5,6.5
+      parent: 1
+  - uid: 765
+    components:
+    - type: Transform
+      pos: -5.5,15.5
+      parent: 1
+  - uid: 802
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,14.5
+      parent: 1
+  - uid: 803
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,13.5
+      parent: 1
+  - uid: 804
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -6.5,12.5
+      parent: 1
+- proto: RailingCornerSmall
+  entities:
+  - uid: 567
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -6.5,15.5
+      parent: 1
+  - uid: 762
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,6.5
+      parent: 1
+  - uid: 764
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -6.5,10.5
+      parent: 1
+- proto: RemoteSignaller
+  entities:
+  - uid: 770
+    components:
+    - type: MetaData
+      name: remote signaller (Open/Close Business)
+    - type: Transform
+      pos: 2.9646325,7.6590786
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        325:
+        - Pressed: DoorBolt
+        766:
+        - Pressed: Toggle
+        767:
+        - Pressed: Toggle
+        768:
+        - Pressed: Toggle
+        769:
+        - Pressed: Toggle
+    - type: Label
+      currentLabel: Open/Close Business
+    - type: NameModifier
+      baseName: remote signaller
+- proto: ServiceTechFab
+  entities:
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -2.5,3.5
+      parent: 1
+- proto: ShelfKitchen
+  entities:
+  - uid: 290
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,8.5
+      parent: 1
+- proto: ShelfWallFreezerWhite
+  entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 580
+    components:
+    - type: MetaData
+      name: wall freezer (Ingredients)
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,7.5
+      parent: 1
+    - type: Label
+      currentLabel: Ingredients
+    - type: NameModifier
+      baseName: wall freezer
+- proto: ShuttersNormalOpen
+  entities:
+  - uid: 766
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 767
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 768
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 769
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 776
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 777
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 778
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 781
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 782
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 783
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 784
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 785
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,18.5
+      parent: 1
+- proto: ShuttleWindow
+  entities:
+  - uid: 34
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,14.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 7.5,14.5
+      parent: 1
+  - uid: 106
+    components:
+    - type: Transform
+      pos: 6.5,4.5
+      parent: 1
+  - uid: 133
+    components:
+    - type: Transform
+      pos: 8.5,12.5
+      parent: 1
+  - uid: 221
+    components:
+    - type: Transform
+      pos: 8.5,13.5
+      parent: 1
+  - uid: 223
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,18.5
+      parent: 1
+  - uid: 224
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,17.5
+      parent: 1
+  - uid: 233
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,16.5
+      parent: 1
+  - uid: 239
+    components:
+    - type: Transform
+      pos: -4.5,17.5
+      parent: 1
+  - uid: 240
+    components:
+    - type: Transform
+      pos: -4.5,18.5
+      parent: 1
+  - uid: 250
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,22.5
+      parent: 1
+  - uid: 628
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,3.5
+      parent: 1
+- proto: SignalButton
+  entities:
+  - uid: 174
+    components:
+    - type: Transform
+      pos: -2.5,8.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        172:
+        - Pressed: Toggle
+  - uid: 788
+    components:
+    - type: MetaData
+      name: signal button (Shutters)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,11.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        778:
+        - Pressed: Toggle
+        776:
+        - Pressed: Toggle
+        775:
+        - Pressed: Toggle
+        777:
+        - Pressed: Toggle
+        783:
+        - Pressed: Toggle
+        784:
+        - Pressed: Toggle
+        785:
+        - Pressed: Toggle
+        782:
+        - Pressed: Toggle
+        781:
+        - Pressed: Toggle
+    - type: Label
+      currentLabel: Shutters
+    - type: NameModifier
+      baseName: signal button
+  - uid: 806
+    components:
+    - type: MetaData
+      name: signal button (Cut Engines)
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,11.5
+      parent: 1
+    - type: DeviceLinkSource
+      linkedPorts:
+        587:
+        - Pressed: Toggle
+        22:
+        - Pressed: Toggle
+        248:
+        - Pressed: Toggle
+        247:
+        - Pressed: Toggle
+        246:
+        - Pressed: Toggle
+        245:
+        - Pressed: Toggle
+        244:
+        - Pressed: Toggle
+        243:
+        - Pressed: Toggle
+        21:
+        - Pressed: Toggle
+        640:
+        - Pressed: Toggle
+        668:
+        - Pressed: Toggle
+        667:
+        - Pressed: Toggle
+        666:
+        - Pressed: Toggle
+        661:
+        - Pressed: Toggle
+        663:
+        - Pressed: Toggle
+        662:
+        - Pressed: Toggle
+        651:
+        - Pressed: Toggle
+        652:
+        - Pressed: Toggle
+        653:
+        - Pressed: Toggle
+        657:
+        - Pressed: Toggle
+        664:
+        - Pressed: Toggle
+        658:
+        - Pressed: Toggle
+        659:
+        - Pressed: Toggle
+        665:
+        - Pressed: Toggle
+        660:
+        - Pressed: Toggle
+        654:
+        - Pressed: Toggle
+        655:
+        - Pressed: Toggle
+        656:
+        - Pressed: Toggle
+        447:
+        - Pressed: Toggle
+    - type: Label
+      currentLabel: Cut Engines
+    - type: NameModifier
+      baseName: signal button
+- proto: SignDirectionalFood
+  entities:
+  - uid: 756
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,13.5
+      parent: 1
+- proto: SignDisposalSpace
+  entities:
+  - uid: 633
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+- proto: SignEngineering
+  entities:
+  - uid: 108
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,5.5
+      parent: 1
+- proto: SignRestroom
+  entities:
+  - uid: 333
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,13.5
+      parent: 1
+- proto: SignVox
+  entities:
+  - uid: 258
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,16.5
+      parent: 1
+- proto: Sink
+  entities:
+  - uid: 216
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,12.5
+      parent: 1
+- proto: SinkStemlessWater
+  entities:
+  - uid: 810
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,6.5
+      parent: 1
+- proto: SMESBasic
+  entities:
+  - uid: 726
+    components:
+    - type: Transform
+      pos: -2.5,1.5
+      parent: 1
+- proto: SodaDispenser
+  entities:
+  - uid: 273
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+- proto: StairWhite
+  entities:
+  - uid: 67
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,19.5
+      parent: 1
+  - uid: 127
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,19.5
+      parent: 1
+  - uid: 128
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,19.5
+      parent: 1
+- proto: StoolBar
+  entities:
+  - uid: 315
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 1
+  - uid: 316
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,16.5
+      parent: 1
+  - uid: 317
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,15.5
+      parent: 1
+  - uid: 318
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,15.5
+      parent: 1
+  - uid: 319
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,16.5
+      parent: 1
+  - uid: 321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,17.5
+      parent: 1
+  - uid: 322
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,17.5
+      parent: 1
+  - uid: 343
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 0.5,17.5
+      parent: 1
+  - uid: 808
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,9.5
+      parent: 1
+  - uid: 809
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,6.5
+      parent: 1
+- proto: SubstationWallBasic
+  entities:
+  - uid: 2
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+- proto: SurveillanceCameraRouterService
+  entities:
+  - uid: 91
+    components:
+    - type: Transform
+      pos: -0.5,3.5
+      parent: 1
+- proto: SurveillanceCameraService
+  entities:
+  - uid: 712
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,19.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: lobby1
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 713
+    components:
+    - type: Transform
+      pos: -3.5,14.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: lobby2
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 715
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: kitchen1
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 716
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,10.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: flyup
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 717
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,8.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: kitchen2
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 718
+    components:
+    - type: Transform
+      pos: -0.5,-0.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: engineering2
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 719
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,4.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: greenhouse
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 720
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: engineering1
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 721
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,15.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: cockpit
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+  - uid: 722
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,7.5
+      parent: 1
+    - type: SurveillanceCamera
+      id: freezer
+    - type: Physics
+      canCollide: False
+    - type: Fixtures
+      fixtures: {}
+- proto: TableCounterMetal
+  entities:
+  - uid: 156
+    components:
+    - type: Transform
+      pos: 1.5,7.5
+      parent: 1
+  - uid: 158
+    components:
+    - type: Transform
+      pos: 2.5,7.5
+      parent: 1
+  - uid: 163
+    components:
+    - type: Transform
+      pos: 3.5,7.5
+      parent: 1
+  - uid: 170
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 1
+- proto: TableCounterWood
+  entities:
+  - uid: 262
+    components:
+    - type: Transform
+      pos: 4.5,18.5
+      parent: 1
+  - uid: 263
+    components:
+    - type: Transform
+      pos: 4.5,17.5
+      parent: 1
+  - uid: 264
+    components:
+    - type: Transform
+      pos: 4.5,16.5
+      parent: 1
+  - uid: 279
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,18.5
+      parent: 1
+  - uid: 280
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,18.5
+      parent: 1
+- proto: TableReinforced
+  entities:
+  - uid: 181
+    components:
+    - type: Transform
+      pos: 5.5,13.5
+      parent: 1
+  - uid: 186
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 204
+    components:
+    - type: Transform
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 205
+    components:
+    - type: Transform
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 210
+    components:
+    - type: Transform
+      pos: 3.5,13.5
+      parent: 1
+  - uid: 278
+    components:
+    - type: Transform
+      pos: -2.5,10.5
+      parent: 1
+  - uid: 327
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,13.5
+      parent: 1
+  - uid: 328
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 7.5,13.5
+      parent: 1
+- proto: TableWood
+  entities:
+  - uid: 265
+    components:
+    - type: Transform
+      pos: 1.5,17.5
+      parent: 1
+  - uid: 266
+    components:
+    - type: Transform
+      pos: 1.5,16.5
+      parent: 1
+  - uid: 267
+    components:
+    - type: Transform
+      pos: 1.5,15.5
+      parent: 1
+- proto: Thruster
+  entities:
+  - uid: 21
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,19.5
+      parent: 1
+  - uid: 22
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,19.5
+      parent: 1
+  - uid: 243
+    components:
+    - type: Transform
+      pos: -4.5,20.5
+      parent: 1
+  - uid: 244
+    components:
+    - type: Transform
+      pos: -3.5,20.5
+      parent: 1
+  - uid: 245
+    components:
+    - type: Transform
+      pos: -2.5,20.5
+      parent: 1
+  - uid: 246
+    components:
+    - type: Transform
+      pos: 3.5,20.5
+      parent: 1
+  - uid: 247
+    components:
+    - type: Transform
+      pos: 4.5,20.5
+      parent: 1
+  - uid: 248
+    components:
+    - type: Transform
+      pos: 5.5,20.5
+      parent: 1
+  - uid: 587
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,16.5
+      parent: 1
+  - uid: 640
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,16.5
+      parent: 1
+  - uid: 651
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,-6.5
+      parent: 1
+  - uid: 652
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,-6.5
+      parent: 1
+  - uid: 653
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 654
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,-6.5
+      parent: 1
+  - uid: 655
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-6.5
+      parent: 1
+  - uid: 656
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 5.5,-6.5
+      parent: 1
+  - uid: 657
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-2.5
+      parent: 1
+  - uid: 658
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-4.5
+      parent: 1
+  - uid: 659
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-2.5
+      parent: 1
+  - uid: 660
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-4.5
+      parent: 1
+  - uid: 661
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-2.5
+      parent: 1
+  - uid: 662
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-4.5
+      parent: 1
+  - uid: 663
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-3.5
+      parent: 1
+  - uid: 664
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,-3.5
+      parent: 1
+  - uid: 665
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 666
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 1
+  - uid: 667
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-3.5
+      parent: 1
+  - uid: 668
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,-2.5
+      parent: 1
+- proto: ToiletEmpty
+  entities:
+  - uid: 215
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,12.5
+      parent: 1
+- proto: ToolboxMechanicalFilled
+  entities:
+  - uid: 65
+    components:
+    - type: Transform
+      parent: 64
+    - type: Physics
+      canCollide: False
+    - type: InsideEntityStorage
+- proto: VendingMachineChefvend
+  entities:
+  - uid: 191
+    components:
+    - type: Transform
+      pos: 2.5,11.5
+      parent: 1
+- proto: VendingMachineDinnerware
+  entities:
+  - uid: 192
+    components:
+    - type: Transform
+      pos: 1.5,11.5
+      parent: 1
+- proto: VendingMachineHappyHonk
+  entities:
+  - uid: 190
+    components:
+    - type: Transform
+      pos: 3.5,11.5
+      parent: 1
+- proto: WallShuttle
+  entities:
+  - uid: 4
+    components:
+    - type: Transform
+      pos: -3.5,-1.5
+      parent: 1
+  - uid: 5
+    components:
+    - type: Transform
+      pos: -2.5,-1.5
+      parent: 1
+  - uid: 6
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 7
+    components:
+    - type: Transform
+      pos: -3.5,-0.5
+      parent: 1
+  - uid: 8
+    components:
+    - type: Transform
+      pos: -3.5,0.5
+      parent: 1
+  - uid: 9
+    components:
+    - type: Transform
+      pos: -3.5,1.5
+      parent: 1
+  - uid: 10
+    components:
+    - type: Transform
+      pos: -3.5,2.5
+      parent: 1
+  - uid: 11
+    components:
+    - type: Transform
+      pos: 4.5,2.5
+      parent: 1
+  - uid: 12
+    components:
+    - type: Transform
+      pos: 4.5,1.5
+      parent: 1
+  - uid: 13
+    components:
+    - type: Transform
+      pos: 4.5,0.5
+      parent: 1
+  - uid: 14
+    components:
+    - type: Transform
+      pos: 4.5,-0.5
+      parent: 1
+  - uid: 15
+    components:
+    - type: Transform
+      pos: 4.5,-1.5
+      parent: 1
+  - uid: 16
+    components:
+    - type: Transform
+      pos: 3.5,-1.5
+      parent: 1
+  - uid: 17
+    components:
+    - type: Transform
+      pos: 2.5,-1.5
+      parent: 1
+  - uid: 18
+    components:
+    - type: Transform
+      pos: -0.5,-1.5
+      parent: 1
+  - uid: 19
+    components:
+    - type: Transform
+      pos: 0.5,-1.5
+      parent: 1
+  - uid: 20
+    components:
+    - type: Transform
+      pos: 1.5,-1.5
+      parent: 1
+  - uid: 23
+    components:
+    - type: Transform
+      pos: 5.5,6.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -2.5,-5.5
+      parent: 1
+  - uid: 28
+    components:
+    - type: Transform
+      pos: 3.5,-5.5
+      parent: 1
+  - uid: 29
+    components:
+    - type: Transform
+      pos: 4.5,-5.5
+      parent: 1
+  - uid: 30
+    components:
+    - type: Transform
+      pos: 5.5,-5.5
+      parent: 1
+  - uid: 32
+    components:
+    - type: Transform
+      pos: -3.5,-4.5
+      parent: 1
+  - uid: 33
+    components:
+    - type: Transform
+      pos: -4.5,-5.5
+      parent: 1
+  - uid: 40
+    components:
+    - type: Transform
+      pos: -3.5,-5.5
+      parent: 1
+  - uid: 41
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 4.5,-4.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -4.5,2.5
+      parent: 1
+  - uid: 100
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 1
+  - uid: 101
+    components:
+    - type: Transform
+      pos: -5.5,4.5
+      parent: 1
+  - uid: 102
+    components:
+    - type: Transform
+      pos: -5.5,3.5
+      parent: 1
+  - uid: 104
+    components:
+    - type: Transform
+      pos: 5.5,2.5
+      parent: 1
+  - uid: 116
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,10.5
+      parent: 1
+  - uid: 120
+    components:
+    - type: Transform
+      pos: -5.5,5.5
+      parent: 1
+  - uid: 121
+    components:
+    - type: Transform
+      pos: 6.5,5.5
+      parent: 1
+  - uid: 122
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,5.5
+      parent: 1
+  - uid: 126
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 129
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,8.5
+      parent: 1
+  - uid: 131
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,5.5
+      parent: 1
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 137
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,6.5
+      parent: 1
+  - uid: 140
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,14.5
+      parent: 1
+  - uid: 178
+    components:
+    - type: Transform
+      pos: 4.5,11.5
+      parent: 1
+  - uid: 179
+    components:
+    - type: Transform
+      pos: 5.5,11.5
+      parent: 1
+  - uid: 180
+    components:
+    - type: Transform
+      pos: 2.5,21.5
+      parent: 1
+  - uid: 182
+    components:
+    - type: Transform
+      pos: -3.5,11.5
+      parent: 1
+  - uid: 183
+    components:
+    - type: Transform
+      pos: -4.5,11.5
+      parent: 1
+  - uid: 184
+    components:
+    - type: Transform
+      pos: -4.5,12.5
+      parent: 1
+  - uid: 185
+    components:
+    - type: Transform
+      pos: -4.5,13.5
+      parent: 1
+  - uid: 199
+    components:
+    - type: Transform
+      pos: 5.5,14.5
+      parent: 1
+  - uid: 201
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,19.5
+      parent: 1
+  - uid: 218
+    components:
+    - type: Transform
+      pos: 6.5,11.5
+      parent: 1
+  - uid: 219
+    components:
+    - type: Transform
+      pos: 7.5,11.5
+      parent: 1
+  - uid: 220
+    components:
+    - type: Transform
+      pos: 8.5,11.5
+      parent: 1
+  - uid: 225
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 2.5,19.5
+      parent: 1
+  - uid: 226
+    components:
+    - type: Transform
+      pos: -1.5,20.5
+      parent: 1
+  - uid: 227
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,19.5
+      parent: 1
+  - uid: 228
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,19.5
+      parent: 1
+  - uid: 229
+    components:
+    - type: Transform
+      pos: -1.5,21.5
+      parent: 1
+  - uid: 230
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 4.5,19.5
+      parent: 1
+  - uid: 231
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,19.5
+      parent: 1
+  - uid: 232
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,15.5
+      parent: 1
+  - uid: 236
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 5.5,19.5
+      parent: 1
+  - uid: 237
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,15.5
+      parent: 1
+  - uid: 238
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,19.5
+      parent: 1
+  - uid: 241
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -4.5,16.5
+      parent: 1
+  - uid: 242
+    components:
+    - type: Transform
+      pos: 2.5,20.5
+      parent: 1
+  - uid: 260
+    components:
+    - type: Transform
+      pos: -1.5,22.5
+      parent: 1
+  - uid: 261
+    components:
+    - type: Transform
+      pos: 2.5,22.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: -3.5,-3.5
+      parent: 1
+  - uid: 394
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,2.5
+      parent: 1
+  - uid: 578
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -4.5,1.5
+      parent: 1
+  - uid: 579
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,9.5
+      parent: 1
+  - uid: 582
+    components:
+    - type: Transform
+      pos: 5.5,10.5
+      parent: 1
+  - uid: 597
+    components:
+    - type: Transform
+      pos: 5.5,7.5
+      parent: 1
+  - uid: 598
+    components:
+    - type: Transform
+      pos: 5.5,8.5
+      parent: 1
+  - uid: 599
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 1
+  - uid: 602
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,14.5
+      parent: 1
+  - uid: 629
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,10.5
+      parent: 1
+  - uid: 630
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 8.5,8.5
+      parent: 1
+  - uid: 631
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 7.5,8.5
+      parent: 1
+  - uid: 648
+    components:
+    - type: Transform
+      pos: -3.5,-2.5
+      parent: 1
+  - uid: 672
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-1.5
+      parent: 1
+- proto: WallShuttleDiagonal
+  entities:
+  - uid: 53
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,6.5
+      parent: 1
+  - uid: 138
+    components:
+    - type: Transform
+      pos: -4.5,6.5
+      parent: 1
+  - uid: 585
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -5.5,1.5
+      parent: 1
+  - uid: 586
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 6.5,1.5
+      parent: 1
+  - uid: 636
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-0.5
+      parent: 1
+- proto: WallShuttleInterior
+  entities:
+  - uid: 3
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+  - uid: 38
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,2.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,2.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -0.5,2.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -2.5,2.5
+      parent: 1
+  - uid: 92
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 99
+    components:
+    - type: Transform
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 110
+    components:
+    - type: Transform
+      pos: -0.5,5.5
+      parent: 1
+  - uid: 115
+    components:
+    - type: Transform
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 118
+    components:
+    - type: Transform
+      pos: 4.5,5.5
+      parent: 1
+  - uid: 123
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,5.5
+      parent: 1
+  - uid: 124
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 1
+  - uid: 125
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,5.5
+      parent: 1
+  - uid: 149
+    components:
+    - type: Transform
+      pos: 2.5,5.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -2.5,8.5
+      parent: 1
+  - uid: 160
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -1.5,8.5
+      parent: 1
+  - uid: 161
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,8.5
+      parent: 1
+  - uid: 164
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -0.5,7.5
+      parent: 1
+  - uid: 175
+    components:
+    - type: Transform
+      pos: 3.5,10.5
+      parent: 1
+  - uid: 176
+    components:
+    - type: Transform
+      pos: 1.5,10.5
+      parent: 1
+  - uid: 177
+    components:
+    - type: Transform
+      pos: 2.5,10.5
+      parent: 1
+  - uid: 194
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,11.5
+      parent: 1
+  - uid: 195
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,11.5
+      parent: 1
+  - uid: 202
+    components:
+    - type: Transform
+      pos: 4.5,13.5
+      parent: 1
+  - uid: 206
+    components:
+    - type: Transform
+      pos: -1.5,12.5
+      parent: 1
+  - uid: 207
+    components:
+    - type: Transform
+      pos: -1.5,13.5
+      parent: 1
+  - uid: 209
+    components:
+    - type: Transform
+      pos: 0.5,13.5
+      parent: 1
+  - uid: 214
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -3.5,13.5
+      parent: 1
+  - uid: 252
+    components:
+    - type: Transform
+      pos: -1.5,17.5
+      parent: 1
+  - uid: 254
+    components:
+    - type: Transform
+      pos: -1.5,18.5
+      parent: 1
+  - uid: 281
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,16.5
+      parent: 1
+  - uid: 583
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 4.5,10.5
+      parent: 1
+- proto: WarningWaste
+  entities:
+  - uid: 96
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 3.5,2.5
+      parent: 1
+- proto: WarpPoint
+  entities:
+  - uid: 324
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 0.5,19.5
+      parent: 1
+- proto: WaterTankHighCapacity
+  entities:
+  - uid: 150
+    components:
+    - type: Transform
+      pos: 2.5,4.5
+      parent: 1
+- proto: WindoorSecure
+  entities:
+  - uid: 187
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 188
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -3.5,9.5
+      parent: 1
+  - uid: 211
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 1.5,13.5
+      parent: 1
+  - uid: 283
+    components:
+    - type: Transform
+      pos: -3.5,16.5
+      parent: 1
+  - uid: 714
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 3.5,13.5
+      parent: 1
+- proto: WindowReinforcedDirectional
+  entities:
+  - uid: 213
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 2.5,13.5
+      parent: 1
+  - uid: 282
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 1
+...


### PR DESCRIPTION
The FTL drive has been removed from the nourishment. The space will remain empty to accommodate a drive being added later.

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:
nourishment.yml (Shuttle file)