### PR TITLE
Removing the FTL drive from the Nourishment

### DIFF
--- a/Resources/Maps/_Null/Shuttles/Civilian/nourishment.yml
+++ b/Resources/Maps/_Null/Shuttles/Civilian/nourishment.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 06/12/2025 07:20:53
-  entityCount: 815
+  time: 06/14/2025 10:22:44
+  entityCount: 814
 maps: []
 grids:
 - 1
@@ -627,7 +627,7 @@ entities:
             0: 65437
           -1,1:
             0: 2063
-            3: 26112
+            2: 26112
           0,2:
             0: 61951
           -1,2:
@@ -641,14 +641,14 @@ entities:
           1,0:
             0: 12288
             1: 2
-            2: 64
+            3: 64
           1,1:
             0: 4355
             1: 25600
           1,2:
             0: 17
             1: 546
-            2: 3268
+            3: 3268
           1,3:
             0: 4335
             1: 49152
@@ -678,18 +678,18 @@ entities:
             0: 8240
           -2,0:
             1: 8
-            2: 64
+            3: 64
             0: 32768
           -2,1:
             1: 9728
-            2: 51200
+            3: 51200
             0: 8
           -2,2:
             1: 8738
-            2: 19660
+            3: 19660
           -2,3:
             1: 25122
-            2: 1092
+            3: 1092
             0: 2048
           -2,4:
             1: 26214
@@ -738,10 +738,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 293.15
+          temperature: 235
           moles:
-          - 0
-          - 0
+          - 27.225372
+          - 102.419266
           - 0
           - 0
           - 0
@@ -753,10 +753,10 @@ entities:
           - 0
           - 0
         - volume: 2500
-          temperature: 235
+          temperature: 293.15
           moles:
-          - 27.225372
-          - 102.419266
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -3589,8 +3589,6 @@ entities:
       pos: -1.5,7.5
       parent: 1
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#990000FF'
 - proto: GasVentScrubberVox
@@ -4198,13 +4196,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,0.5
-      parent: 1
-- proto: MachineFTLDrive
-  entities:
-  - uid: 73
-    components:
-    - type: Transform
-      pos: 0.5,-0.5
       parent: 1
 - proto: NapkinDrum5
   entities:

--- a/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
+++ b/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
@@ -8,7 +8,7 @@
 - type: vessel
   id: Nourishment
   parent: BaseVessel
-  name: UNJ Nourishment
+  name: UCE Nourishment
   description: A top of the line Restaurant Support Vessel. Includes a Vox dining area and space fly-up counter.
   price: 69000
   category: Small


### PR DESCRIPTION
Fixed the error caused by the previous PR I made for this change.
Removed the FTL Drive
Added the ship the UCE fleet

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:
modified:   Resources/Maps/_Null/Shuttles/Civilian/nourishment.yml
modified:   Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml

