### PR TITLE
Renaming Ursadine

### DIFF
--- a/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
+++ b/Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
@@ -9,7 +9,7 @@
   id: Nourishment
   parent: BaseVessel
   name: UCE Nourishment
-  description: A top of the line Restaurant Support Vessel. Includes a Vox dining area and space fly-up counter.
+  description: A luxury Restaurant Vessel. Includes a Vox dining area and space fly-up counter.
   price: 69000
   category: Small
   group: Shipyard
@@ -22,7 +22,7 @@
 
 - type: gameMap
   id: Nourishment
-  mapName: 'Nourishment'
+  mapName: 'UCE Nourishment'
   mapPath: /Maps/_Null/Shuttles/Civilian/nourishment.yml
   minPlayers: 0
   stations:

--- a/Resources/Prototypes/_Null/Shipyard/Medical/pulse.yml
+++ b/Resources/Prototypes/_Null/Shipyard/Medical/pulse.yml
@@ -15,7 +15,6 @@
   shuttlePath: /Maps/_Null/Shuttles/Medical/pulse.yml
   guidebookPage: ShipyardPulse
   class:
-  - Civilian
   - Medical
   engine:
   - Uranium

--- a/Resources/Prototypes/_Null/Shipyard/Research/insight.yml
+++ b/Resources/Prototypes/_Null/Shipyard/Research/insight.yml
@@ -7,7 +7,7 @@
 - type: vessel
   id: Insight
   parent: BaseVessel
-  name: C1R Insight
+  name: UCE Insight
   description: An artifact research vessel with room for 3 crew
   price: 75000
   category: Medium
@@ -21,7 +21,7 @@
 
 - type: gameMap
   id: Insight
-  mapName: 'Insight'
+  mapName: 'UCE Insight'
   mapPath: /Maps/_Null/Shuttles/Research/insight.yml
   minPlayers: 0
   stations:

--- a/Resources/ServerInfo/_Null/Guidebook/Shipyard/Insight.xml
+++ b/Resources/ServerInfo/_Null/Guidebook/Shipyard/Insight.xml
@@ -1,5 +1,5 @@
 <Document>
-  # INSIGHT
+  # UCE INSIGHT
   <Box>
   <GuideEntityEmbed Entity="SignAnomaly"/>
   <GuideEntityEmbed Entity="SignSalvage"/>
@@ -14,9 +14,9 @@
 
     [color=#a4885c]Weapons:[/color] 4x L85 Autocannons
 
-	[color=#a4885c]IFF Designation:[/color] Civilian
+	[color=#a4885c]IFF Designation:[/color] Science
 
-  "The Ursadyne Insight, a top of the line xenoarchaeology vessel"
+  "Manufactured by the Ursadine Collective, the Insight is a top of the line xenoarchaeology vessel"
 
   # SHIP FEATURES
 

--- a/Resources/ServerInfo/_Null/Guidebook/Shipyard/Nourishment.xml
+++ b/Resources/ServerInfo/_Null/Guidebook/Shipyard/Nourishment.xml
@@ -1,5 +1,5 @@
 <Document>
-  # NOURISHMENT
+  # UCE NOURISHMENT
   <Box>
   <GuideEntityEmbed Entity="SignKitchen"/>
   </Box>
@@ -15,7 +15,7 @@
 
 	[color=#a4885c]IFF Designation:[/color] Civilian
 
-  "The Ursadyne Nourishment, a top of the line Restaurant Support Vessel. It has a full kitchen, greenhouse, and service area. It includes a Vox dining area and a convienent fly-up counter."
+  "Manufactured by the Ursadine Collective, the Nourishment is a luxury Food Support Vessel. It has a full kitchen, greenhouse, and service area. It includes a Vox dining area and a convienent fly-up counter."
 
   # SHIP FEATURES
 

--- a/Resources/ServerInfo/_Null/Guidebook/Shipyard/Pulse.xml
+++ b/Resources/ServerInfo/_Null/Guidebook/Shipyard/Pulse.xml
@@ -15,7 +15,7 @@
 
 	[color=#a4885c]IFF Designation:[/color] Medical
 
-  "The Ursadyne Pulse, a light, fast emergency medical service vessel. It is equipped with a functional medbay and an FLT drive, allowing it to quickly respond to sector medical needs."
+  "Manufactured by the Ursadine Collective, the Pulse is a light, fast emergency medical service vessel. It is equipped with a functional medbay and an FLT drive, allowing it to quickly respond to sector medical needs."
 
   # SHIP FEATURES
 


### PR DESCRIPTION
Updated shipyard and guidebook entries to reflect the new spelling of Ursadine 
Ensured UCE prefix is consistent across all entries

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

:cl:
modified:   Resources/Prototypes/_Null/Shipyard/Civilian/nourishment.yml
modified:   Resources/Prototypes/_Null/Shipyard/Medical/pulse.yml
modified:   Resources/Prototypes/_Null/Shipyard/Research/insight.yml
modified:   Resources/ServerInfo/_Null/Guidebook/Shipyard/Insight.xml
modified:   Resources/ServerInfo/_Null/Guidebook/Shipyard/Nourishment.xml
modified:   Resources/ServerInfo/_Null/Guidebook/Shipyard/Pulse.xml
