### PR TITLE
Fixed ATV Name & Description Absence

### DIFF
--- a/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Vehicles/vehicles.yml
@@ -2,6 +2,8 @@
 - type: entity
   parent: VehicleATV
   id: NFVehicleATV
+  name: ATV
+  description: An all-terrain vehicle. It's illegal on some planets.
   components:
   - type: Sprite
     sprite: _NF/Objects/Vehicles/atv.rsi


### PR DESCRIPTION
All I had done was force it. It's not a "proper" localization fix.
