### PR TITLE
security_uplink_catalog Tuning

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
+++ b/Resources/Prototypes/_NF/Catalog/security_uplink_catalog.yml
@@ -110,7 +110,7 @@
   productEntity: ClothingOuterHardsuitNfsdExperimental
   icon: { sprite: _NF/Clothing/OuterClothing/Hardsuits/nfsd_experimental.rsi, state: icon }
   cost:
-    FrontierUplinkCoin: 75 # Death sqaud armor is very hard to get now!
+    FrontierUplinkCoin: 75
   categories:
     - UplinkSecurityHardsuits
   conditions:
@@ -273,7 +273,7 @@
   productEntity: WeaponLaserCarbine
   icon: { sprite: Objects/Weapons/Guns/Battery/laser_gun.rsi, state: icon }
   cost:
-    FrontierUplinkCoin: 1 # GARBAGE!!!
+    FrontierUplinkCoin: 1
   categories:
     - UplinkSecurityWeapons
   conditions:
@@ -289,7 +289,7 @@
   productEntity: WeaponDisablerSMG
   icon: { sprite: Objects/Weapons/Guns/Battery/disabler_smg.rsi, state: base }
   cost:
-    FrontierUplinkCoin: 5 # STUNMETA!!!
+    FrontierUplinkCoin: 5
   categories:
     - UplinkSecurityWeapons
   conditions:
@@ -535,7 +535,7 @@
   productEntity: CombatMedipen
   icon: { sprite: Objects/Specific/Medical/medipen.rsi, state: morphen }
   cost:
-    FrontierUplinkCoin: 2 # Omni is an all around total healer, why does it cost the same as all the others?
+    FrontierUplinkCoin: 2
   categories:
     - UplinkSecurityUtility
   conditions:
@@ -859,7 +859,7 @@
   productEntity: WeaponPulsePistol
   icon: { sprite: Objects/Weapons/Guns/Battery/pulse_pistol.rsi, state: base }
   cost:
-    FrontierUplinkCoin: 20 # Extremely strong weapon, now costs all of the starting coins!
+    FrontierUplinkCoin: 20
   categories:
     - UplinkSecurityWeapons
   conditions:
@@ -880,7 +880,7 @@
   productEntity: WeaponPulseCarbine
   icon: { sprite: Objects/Weapons/Guns/Battery/pulse_carbine.rsi, state: base }
   cost:
-    FrontierUplinkCoin: 65 # This does not need to be explained any further....
+    FrontierUplinkCoin: 65
   categories:
     - UplinkSecurityWeapons
   conditions:


### PR DESCRIPTION
I, a person that always plays MC has seen a few items are extremely busted, I'm working on something larger but for now this minor edit should fix the extreme cheese!

The slightly weaker reskinned Death-Squad armor is NOT able to be gotten at round start anymore!
Omni pen is now more costly than the others, omni heals all basic types of damage at the same time, the best medi pen.
Pulse pistol now costs all of your starting cash! If your getting a pulse weapon you do not need anymore help!
Pulse carbine is very costly, need I explain why you shouldn't get this round start?