### PR TITLE
Small fixes and buffs part 1 (fixed)

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -96,7 +96,7 @@ public abstract partial class SharedGunSystem
             // Continuous loading
             _doAfter.TryStartDoAfter(new DoAfterArgs(EntityManager, args.User, fillDelay, new AmmoFillDoAfterEvent(), used: uid, target: args.Target, eventTarget: uid) // Frontier: component.FillDelay<fillDelay
             {
-                BreakOnMove = true,
+                BreakOnMove = false, //need some fix to avoid the massive mag reload
                 BreakOnDamage = false,
                 NeedHand = true
             });

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Ammunition/Magazines/caseless_rifle.yml
@@ -42,7 +42,7 @@
     proto: CartridgeCaselessRifle
     capacity: 10
   - type: Item
-    size: Tiny
+    size: Small
   - type: Sprite
     sprite: Objects/Weapons/Guns/Ammunition/Magazine/CaselessRifle/caseless_rifle_mag_short.rsi
     layers:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -599,6 +599,8 @@
   id: WeaponAntiqueLaser
   description: This is an antique laser pistol. All craftsmanship is of the highest quality. It is decorated with a mahogany grip and chrome filigree. The object menaces with spikes of energy. On the item is an image of a captain and a clown. The clown is dead. The captain is striking a heroic pose.
   components:
+  - type: Item
+    size: Small
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/antiquelasergun.rsi
     layers:
@@ -645,7 +647,7 @@
   description: An experimental civilian grade high-energy laser pistol with a self-charging nuclear battery.
   components:
   - type: Item
-    size: Normal  # Intentionally larger than other pistols
+    size: Small  # Intentionally larger than other pistols
   - type: Sprite
     sprite: Objects/Weapons/Guns/Battery/advancedlasergun.rsi
     layers:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Ammunition/Magazines/light_rifle.yml
@@ -28,7 +28,7 @@
     proto: null
     capacity: 15
   - type: Item
-    size: Tiny
+    size: Small
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Ammunition/Magazine/LightRifle/light_rifle_cap_mag.rsi
     layers:

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -172,8 +172,8 @@
       path: /Audio/Weapons/Guns/Gunshots/flaregun.ogg
     projectileSpeed: 15
   - type: Battery
-    maxCharge: 720
-    startingCharge: 720
+    maxCharge: 1200
+    startingCharge: 1200
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 10

--- a/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Crossbow/crossbow.yml
+++ b/Resources/Prototypes/_NF/Entities/Objects/Weapons/Guns/Crossbow/crossbow.yml
@@ -311,6 +311,8 @@
   parent: [ BaseCrossbow, BaseC1Contraband ]
   name: hand crossbow
   components:
+  - type: Item
+    size: Small
   - type: UseDelay
     delay: 0.5
   - type: Sprite
@@ -324,6 +326,8 @@
   parent: [ BaseCrossbow, BaseC1Contraband ]
   name: impovised hand crossbow
   components:
+  - type: Item
+    size: Small
   - type: UseDelay
     delay: 2
   - type: Sprite
@@ -337,6 +341,8 @@
   parent: [ BaseCrossbow, BaseC3CultContraband ]
   name: blood cult hand crossbow
   components:
+  - type: Item
+    size: Small
   - type: Sprite
     sprite: _NF/Objects/Weapons/Guns/Crossbow/culthand.rsi
   - type: StaticPrice


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->
It just a list of small modification and fixes, mostly to make sense to some stuff and consistency.
Changes:
- small capacity magazines of .30/.25 are no longer tiny and are now small like the rest of magazines.
- you can now reload while moving
- holoflare now have 5 charges same like frontier.
- advanced laser pistol and antique are now small items, for consistency with the rest of pistols.
- hand crossbows are now small
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
- small magazines of .30/.25 are no longer tiny and are now small like the rest of magazines.
  it make no sense to fill a pack of cigarettes with 10+ mags, and it was just 2 orphan mags with different size

- you can now reload while moving
  So "low" tier guns are more useful in combat compared to automatic ones, mostly shotguns, revolvers, and any no magazine rifle like the ceremonial rifle

- holoflare now have 5 charges same like frontier.
  It make a better use of the holoflare, not many charges not to little, is a good spot.

- advanced laser pistol and antique are now small items, for consistency with the rest of pistols.
  Make no sense to be a size bigger that the rest of the pistols, since they get  used less that way because it lack the dynamic of the rest of the pistols, like put them on pockets, or in the boots.

- hand crossbows are now small
 Is a relative small crossbow, same like the rest of the pistols, it make them more dynamic for this who want a gimmick weapon (see imagine for suggested use)

## How to test
<!-- Describe the way it can be tested -->
- spawn the items needed (any shotgun and bullets, small capacity mags .35/.20, hand crossbows,holoflare, advanced laser pistol and antique)
- observe the item description
- the laser pistols can now be used on pockets,
- shot a shotgun and try to reload while moving, it now works.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![TEST](https://github.com/user-attachments/assets/44fe5c4b-383a-4973-a369-24eaf24b1e06)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: You can now reload non-magazine guns while you move.
- tweak: small capacity magazines (.20/.30) now are on par with the rest of magazines.
- tweak: Holoflares now have 5 charges.
- tweak: antique and advanced laser pistols are smaller, so they can be carried on the pocket slot.
- tweak: hand crossbows are smaller, so they can be carried on the pocket slot.