### PR TITLE
Add .45 Magnum to Techfabs

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/security.yml
@@ -41,6 +41,9 @@
   - MagazineLightRifle
   - MagazineLightRifleRubber # Frontier
   - MagazineLightRifleEmpty
+  - MagazineMagnum
+  - MagazineMagnumRubber
+  - MagazineMagnumEmpty
   - MagazinePistol
   - MagazinePistolRubber # Frontier
   - MagazinePistolEmpty

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/mercenary_techfab.yml
@@ -92,6 +92,7 @@
 ## Ammo boxes
   - BoxLethalshot
   - MagazineBoxLightRifle
+  - MagazineBoxMagnum
   - MagazineBoxPistol
   - MagazineBoxRifle
   - CrossbowBolt
@@ -111,6 +112,9 @@
   - MagazineLightRifleLowCapacityRubber
   - MagazineLightRifle
   - MagazineLightRifleEmpty
+  - MagazineMagnumEmpty
+  - MagazineMagnum
+  - MagazineMagnumRubber
   - MagazineRifle
   - MagazineRifleEmpty
   - MagazinePistol
@@ -118,6 +122,8 @@
   - SpeedLoaderRifleHeavy
   - SpeedLoaderRifleHeavyEmpty
   - SpeedLoaderRifleHeavyRubber
+  - SpeedLoaderMagnum
+  - SpeedLoaderMagnumEmpty
   - SpeedLoaderMagnumRubber
   - MagazineRifleRubber
   - MagazineShotgunSlug

--- a/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/nfsd_techfab.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/Packs/Deprecated/nfsd_techfab.yml
@@ -22,6 +22,9 @@
   - MagazineBoxRiflePractice
   - MagazineLightRifle
   - MagazineLightRifleEmpty
+  - MagazineMagnumEmpty
+  - MagazineMagnum
+  - MagazineMagnumRubber
   - MagazinePistol
   - MagazinePistolEmpty
   - MagazinePistolSubMachineGun

--- a/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
+++ b/Resources/Prototypes/_NF/Recipes/Lathes/security.yml
@@ -59,6 +59,28 @@
   materials:
     Steel: 245 # 20 [Steel per empty mag] + 15 [bullets] * 15 [Steel per bullet]
 
+- type: latheRecipe # mauser mag empty
+  id: MagazineMagnumEmpty
+  parent: BaseAmmoRecipe
+  result: MagazineMagnumEmpty
+  materials:
+    Steel: 25
+
+- type: latheRecipe # mauser mag rubber
+  id: MagazineMagnumRubber
+  parent: BaseAmmoRecipe
+  result: MagazineMagnumRubber
+  materials:
+    Steel: 65
+    Plastic: 135
+
+- type: latheRecipe # mauser mag full
+  id: MagazineMagnum
+  parent: BaseAmmoRecipe
+  result: MagazineMagnum
+  materials:
+    Steel: 200
+
 - type: latheRecipe
   id: SpeedLoaderRifleHeavyEmpty
   parent: BaseEmptyAmmoRecipe


### PR DESCRIPTION
Simply adds .45 magnum ammo and .45 magazines to all fabs that print ammo, these fab types are:
- Mercenary
- Ammo
- Militia
- And depreciated fabs