### PR TITLE
Added RCD Module to Exosuit Fabricator

### DIFF
--- a/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/Packs/robotics.yml
@@ -15,7 +15,6 @@
   - BorgModuleFireExtinguisher
   - BorgModuleRadiationDetection
   - BorgModuleTool
-  - BorgModuleRCD
   - BorgModuleSurgery # Shitmed Change
 
 - type: latheRecipePack
@@ -57,6 +56,7 @@
   - BorgModuleAdvancedCleaning
   - BorgModuleAdvancedTool
   - BorgModuleGPS
+  - BorgModuleRCD
   - BorgModuleArtifact
   - BorgModuleAnomaly
   - BorgModuleGardening


### PR DESCRIPTION


## About the PR
This adds the RCD mod to the exo suit fab, no research required.

## Why / Balance
Requested change

## How to Test
look into the exo suit fab

## Media
<img width="505" height="439" alt="image" src="https://github.com/user-attachments/assets/27ebb176-5f0f-456b-b035-85bdc30cbca7" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read the [Null Sector Bible](https://docs.google.com/document/d/1KWj932ajnTZ7PjBH1D_U1bcHJWaYCDkXgrn-K7vc7CA/edit?usp=sharing)'s guidelines on making a PR, and do solemnly swear that I am not pushing a broken work that'll brick the repository.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes (For Other Forks)
none
