### PR TITLE
Fixed Reinforced Wall Sprite in Build Menu

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/structures.yml
+++ b/Resources/Prototypes/Recipes/Construction/structures.yml
@@ -61,7 +61,7 @@
   category: construction-category-structures
   description: Keeps the air in and the greytide out.
   icon:
-    sprite: _NF/Structures/Walls/solid.rsi # Frontier
+    sprite: Structures/Walls/solid.rsi # Frontier
     state: full
   objectType: Structure
   placementMode: SnapgridCenter
@@ -79,7 +79,7 @@
   category: construction-category-structures
   description: Keeps the air in and the greytide out.
   icon:
-    sprite: _NF/Structures/Walls/solid.rsi # Frontier
+    sprite: Structures/Walls/solid.rsi # Frontier
     state: rgeneric
   objectType: Structure
   placementMode: SnapgridCenter


### PR DESCRIPTION
## About the PR
Fixes the wall sprite in the build menu

## Why / Balance
bug

## How to Test
open build menu.
See check sprite matches the sprite shown in game.

## Media
<img width="286" height="285" alt="image" src="https://github.com/user-attachments/assets/0383e025-505c-4852-85e4-2153c34b47f1" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read the [Null Sector Bible](https://docs.google.com/document/d/1KWj932ajnTZ7PjBH1D_U1bcHJWaYCDkXgrn-K7vc7CA/edit?usp=sharing)'s guidelines on making a PR, and do solemnly swear that I am not pushing a broken work that'll brick the repository.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes (For Other Forks)
<!-- List any breaking changes that other forks may experience, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
