### PR TITLE
Fix Window Cracks Not Overlaying Correctly

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -67,6 +67,11 @@
   - type: Sprite
     drawdepth: WallTops
     sprite: _NF/Structures/Windows/window.rsi # Frontier
+    layers:
+    - map: [ "enum.CornerLayers.SE" ]
+    - map: [ "enum.CornerLayers.NE" ]
+    - map: [ "enum.CornerLayers.NW" ]
+    - map: [ "enum.CornerLayers.SW" ]
   - type: Icon
     sprite: _NF/Structures/Windows/window.rsi # Frontier
     state: full


### PR DESCRIPTION
## About the PR
This fixes the layering of the windows

## Why / Balance
fixes a bug.

## How to Test
spawn plasma window, damage it, notice the cracks are on top instead of below.

## Media
<img width="436" height="505" alt="image" src="https://github.com/user-attachments/assets/e724766f-bde8-4ecc-9de3-3d9f759a0741" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read the [Null Sector Bible](https://docs.google.com/document/d/1KWj932ajnTZ7PjBH1D_U1bcHJWaYCDkXgrn-K7vc7CA/edit?usp=sharing)'s guidelines on making a PR, and do solemnly swear that I am not pushing a broken work that'll brick the repository.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes (For Other Forks)
<!-- List any breaking changes that other forks may experience, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
