### PR TITLE
Improve Error Message of the Flatpack Collision Error 

### DIFF
--- a/Resources/Locale/en-US/construction/components/flatpack.ftl
+++ b/Resources/Locale/en-US/construction/components/flatpack.ftl
@@ -1,4 +1,5 @@
 flatpack-unpack-no-room = No room to unpack!
+flatpack-unpack-blocked-by = The flatpack is being blocked by '{$name}'!
 flatpack-examine = Use a [color=yellow]multitool[/color] to unpack this.
 flatpack-entity-name = {$name} flatpack
 flatpack-entity-description = A flatpack used for constructing {INDEFINITE($name)} {$name}.


### PR DESCRIPTION


## About the PR
This fixes the issue where flatpack can't be opened and also adds an improved error message to help users firgure out why they can't open it.
## Why / Balance
this is a bug fix

## How to Test
spawn multiple flatpacks each blocked by different objects, e.g. tables. chairs. walls...
try to unpack and pay special attention to the error message.


## Media
<img width="443" height="173" alt="image" src="https://github.com/user-attachments/assets/e17a40f1-a11a-4cd9-8289-8dd272b62844" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read the [Null Sector Bible](https://docs.google.com/document/d/1KWj932ajnTZ7PjBH1D_U1bcHJWaYCDkXgrn-K7vc7CA/edit?usp=sharing)'s guidelines on making a PR, and do solemnly swear that I am not pushing a broken work that'll brick the repository.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes (For Other Forks)
none