### PR TITLE
Allow Portable Recharger To Be Worn In The Suit Slot

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -14,8 +14,9 @@
     quickEquip: false
     slots:
     - back
+    - suitStorage
   - type: Charger
-    chargeRate: 50 # Frontier: chargeRate: 50 
+    chargeRate: 50 # Frontier: chargeRate: 50
     slotId: charger_slot
     portable: true
   - type: PowerChargerVisuals


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR adds the ability for the portable recharger to fit in the suit slot. So you can wear it on your back like a fire axe or other gun.

## Why / Balance
no reason to give up your entire inventory for the ability to recharge your gun.

## How to Test
<!-- Describe the way it can be tested -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). You may remove this if this PR is only about Small fixes/refactors. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I have read the [Null Sector Bible](https://docs.google.com/document/d/1KWj932ajnTZ7PjBH1D_U1bcHJWaYCDkXgrn-K7vc7CA/edit?usp=sharing)'s guidelines on making a PR, and do solemnly swear that I am not pushing a broken work that'll brick the repository.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking Changes (For Other Forks)
<!-- List any breaking changes that other forks may experience, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them. -->
