### PR TITLE
Tuned Lithium Chemical Barrel Cost

### DIFF
--- a/Resources/Prototypes/_NF/Catalog/Cargo/cargo_medical.yml
+++ b/Resources/Prototypes/_NF/Catalog/Cargo/cargo_medical.yml
@@ -135,7 +135,7 @@
     sprite: _NF/Objects/Storage/Barrels/grey.rsi
     state: icon
   product: ChemicalBarrelLithium
-#  cost: 7000
+  cost: 7000
   category: cargoproduct-category-name-medical
   group: market
 


### PR DESCRIPTION
Fixes lithium costing zero but selling for more than that, should be merged and applied quickly due to nature of this bug.